### PR TITLE
Add Headers and fixes to package objects

### DIFF
--- a/summingbird-example/src/main/scala/com/twitter/summingbird/package.scala
+++ b/summingbird-example/src/main/scala/com/twitter/summingbird/package.scala
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+package com.twitter.summingbird
+
 /**
   * The "example" package contains all of the code and configuration
   * necessary to run a basic Summingbird job locally that consumes
@@ -57,4 +59,4 @@
   * sritchie@twitter.com, or send me a tweet at @sritchie. Once you
   * get this code compiling and running, you'll be cooking with gas!
   */
-object example { }
+package object example { }

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/package.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/package.scala
@@ -1,3 +1,19 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
 package com.twitter.summingbird
 
 import com.twitter.scalding.TypedPipe

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/package.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/package.scala
@@ -1,3 +1,19 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
 package com.twitter.summingbird
 
 import com.twitter.storehaus.ReadableStore


### PR DESCRIPTION
I was missing the package declaration at the top of example's package object file. Quick fix, plus headers.
