### PR TITLE
Join passes the test

### DIFF
--- a/summingbird-scalding/src/test/scala/com/twitter/summingbird/scalding/ScaldingLaws.scala
+++ b/summingbird-scalding/src/test/scala/com/twitter/summingbird/scalding/ScaldingLaws.scala
@@ -98,6 +98,54 @@ class TestStore[K, V](store: String, inBatcher: Batcher, initBatch: BatchID, ini
   }
 }
 
+class TestService[K, V](service: String,
+  inBatcher: Batcher,
+  lasts: Map[BatchID, Iterable[(Time, (K, V))]],
+  streams: Map[BatchID, Iterable[(Time, (K, Option[V]))]])
+(implicit ord: Ordering[K],
+  tset: TupleSetter[(Time, (K, Option[V]))],
+  tset2: TupleSetter[(Time, (K, V))],
+  tconv: TupleConverter[(Time, (K, Option[V]))],
+  tconv2: TupleConverter[(Time, (K, V))])
+  extends BatchedService[K, V] {
+
+  val batcher = inBatcher
+  val ordering = ord
+  val reducers = None
+  // Needed to init the Test mode:
+  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] =
+    (lasts.map { case (b, it) => lastMappable(b) -> toBuffer(it) } ++
+      streams.map { case (b, it) => streamMappable(b) -> toBuffer(it) }).toMap
+
+  def lastMappable(b: BatchID): Mappable[(Time, (K, V))] =
+    new MockMappable[(Time, (K, V))](service + "/last/" + b.toString)
+
+  def streamMappable(b: BatchID): Mappable[(Time, (K, Option[V]))] =
+    new MockMappable[(Time, (K, Option[V]))](service + "/stream/" + b.toString)
+
+  def toBuffer[T](it: Iterable[T])(implicit ts: TupleSetter[T]): Buffer[Tuple] =
+    it.map { ts(_) }.toBuffer
+
+  override def readStream(batchID: BatchID, mode: Mode): Option[FlowToPipe[(K, Option[V])]] = {
+    streams.get(batchID).map { iter =>
+      val mappable = streamMappable(batchID)
+      Reader { (fd: (FlowDef, Mode)) => TypedPipe.from(mappable)(fd._1, fd._2, mappable.converter) }
+    }
+  }
+  override def readLast(exclusiveUB: BatchID, mode: Mode): Try[(BatchID, FlowToPipe[(K, V)])] = {
+    val candidates = lasts.filter { _._1 < exclusiveUB }
+    if(candidates.isEmpty) {
+      Left(List("No batches < :" + exclusiveUB.toString))
+    }
+    else {
+      val (batch, _) = candidates.maxBy { _._1 }
+      val mappable = lastMappable(batch)
+      val rdr = Reader { (fd: (FlowDef, Mode)) => TypedPipe.from(mappable)(fd._1, fd._2, mappable.converter) }
+      Right((batch, rdr))
+    }
+  }
+}
+
 object ScaldingLaws extends Properties("Scalding") {
   // TODO: These functions were lifted from Storehaus's testing
   // suite. They should move into Algebird to make it easier to test
@@ -126,23 +174,25 @@ object ScaldingLaws extends Properties("Scalding") {
 
   implicit def tupleExtractor[T <: (Long, _)]: TimeExtractor[T] = TimeExtractor( _._1 )
 
+  val simpleBatcher = new Batcher {
+    def batchOf(d: java.util.Date) =
+      if (d.getTime == Long.MaxValue) BatchID(2)
+      else if (d.getTime >= 0L) BatchID(1)
+      else BatchID(0)
+
+    def earliestTimeOf(batch: BatchID) = batch.id match {
+      case 0L => new java.util.Date(Long.MinValue)
+      case 1L => new java.util.Date(0)
+      case 2L => new java.util.Date(Long.MaxValue)
+    }
+  }
+
   property("ScaldingPlatform matches Scala for single step jobs, with everything in one Batch") =
     forAll { (original: List[Int], fn: (Int) => List[(Int, Int)]) =>
       val inMemory = TestGraphs.singleStepInScala(original)(fn)
       // Add a time:
       val inWithTime = original.zipWithIndex.map { case (item, time) => (time.toLong, item) }
-      val batcher = new Batcher {
-        def batchOf(d: java.util.Date) =
-          if (d.getTime == Long.MaxValue) BatchID(2)
-          else if (d.getTime >= 0L) BatchID(1)
-          else BatchID(0)
-
-        def earliestTimeOf(batch: BatchID) = batch.id match {
-          case 0L => new java.util.Date(Long.MinValue)
-          case 1L => new java.util.Date(0)
-          case 2L => new java.util.Date(Long.MaxValue)
-        }
-      }
+      val batcher = simpleBatcher
       import Dsl._ // Won't be needed in scalding 0.9.0
       val testStore = new TestStore[Int,Int]("test", batcher, BatchID(0), Iterable.empty, BatchID(1))
       val (buffer, source) = testSource(inWithTime)
@@ -155,6 +205,56 @@ object ScaldingLaws extends Properties("Scalding") {
         TestMode(testStore.sourceToBuffer ++ buffer))
 
       scald.run(scald.plan(summer))
+      // Now check that the inMemory ==
+
+      val smap = testStore.lastToIterable(BatchID(1)).map { _._2 }.toMap
+      Monoid.isNonZero(Group.minus(inMemory, smap)) == false
+    }
+
+  property("ScaldingPlatform matches Scala for leftJoin jobs, with everything in one Batch") =
+    forAll { (original: List[Int],
+      prejoinMap: (Int) => List[(Int, Int)],
+      service: (Int,Int) => Option[Int],
+      postJoin: ((Int, (Int, Option[Int]))) => List[(Int, Int)]) =>
+
+      // We need to keep track of time correctly to use the service
+      var fakeTime = -1
+      val timeIncIt = new Iterator[Int] {
+        val inner = original.iterator
+        def hasNext = inner.hasNext
+        def next = {
+          fakeTime += 1
+          inner.next
+        }
+      }
+      val srvWithTime = { (key: Int) => service(fakeTime, key) }
+      val inMemory = TestGraphs.leftJoinInScala(timeIncIt)(srvWithTime)(prejoinMap)(postJoin)
+
+      // Add a time:
+      val allKeys = original.flatMap(prejoinMap).map { _._1 }
+      val allTimes = (0 until original.size)
+      val stream = for { time <- allTimes; key <- allKeys; v = service(time, key) } yield (time.toLong, (key, v))
+
+      val inWithTime = original.zipWithIndex.map { case (item, time) => (time.toLong, item) }
+      val batcher = simpleBatcher
+      import Dsl._ // Won't be needed in scalding 0.9.0
+      val testStore = new TestStore[Int,Int]("test", batcher, BatchID(0), Iterable.empty, BatchID(1))
+      val testService = new TestService[Int, Int]("srv",
+        batcher,
+        Map(BatchID(0) -> Iterable.empty),
+        Map(BatchID(1) -> stream))
+
+      val (buffer, source) = testSource(inWithTime)
+
+      val summer =
+        TestGraphs.leftJoinJob[Scalding,(Long, Int),Int,Int,Int,Int](source, testService, testStore) { tup => prejoinMap(tup._2) }(postJoin)
+
+      val intr = Interval.leftClosedRightOpen(0L, original.size.toLong)
+      val scald = new Scalding("scalaCheckleftJoinJob",
+        intr,
+        TestMode(testStore.sourceToBuffer ++ buffer ++ testService.sourceToBuffer))
+
+      scald.run(summer)
       // Now check that the inMemory ==
 
       val smap = testStore.lastToIterable(BatchID(1)).map { _._2 }.toMap


### PR DESCRIPTION
Had to change a type (this is where I love types, they help you refactor so well).

A stream from a store has to have `Option[V`] on the values (obviously), otherwise keys cannot be deleted.

This is really the batch version of storehaus, as @sritchie predicted.
