### PR TITLE
Adds code and tests for computing dependencies

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Dependants.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Dependants.scala
@@ -1,0 +1,60 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.summingbird
+
+/** Producers are Directed Acyclic Graphs
+ * by the fact that they are immutable.
+ */
+case class Dependants[P <: Platform[P]](tail: Producer[P, _]) {
+  private val graph: Map[Producer[P, _], Set[Producer[P, _]]] = {
+    val empty = Map[Producer[P, _], Set[Producer[P, _]]]()
+
+    (Producer.transitiveDependenciesOf(tail) + tail)
+      .foldLeft(empty) { (graph, child) =>
+        val withChild = graph + (child -> graph.getOrElse(child, Set[Producer[P, _]]()))
+        Producer.dependenciesOf(child)
+          .foldLeft(withChild) { (innerg, parent) =>
+            innerg + (parent -> (innerg.getOrElse(parent, Set[Producer[P, _]]()) + child))
+          }
+      }
+  }
+  private val depths: Map[Producer[P, _], Int] = computeDepth(graph.keys.toSet, Map.empty)
+
+  @annotation.tailrec
+  private def computeDepth(todo: Set[Producer[P, _]], acc: Map[Producer[P, _], Int]): Map[Producer[P, _], Int] =
+    if(todo.isEmpty) acc
+    else {
+      def withParents(n: Producer[P, _]) = (Producer.dependenciesOf(n) + n).filterNot { acc.contains(_) }
+
+      val (done, rest) = todo.map { withParents(_) }.partition { _.size == 1 }
+      val newTodo = rest.flatten
+      val newAcc = acc ++ (done.flatten.map { n =>
+        val depth = Producer.dependenciesOf(n)
+          .map { acc(_) + 1 }
+          .reduceOption { _ max _ }
+          .getOrElse(0)
+        n -> depth
+      })
+      computeDepth(newTodo, newAcc)
+    }
+  /** The max of zero and 1 + depth of all parents if the node is the graph
+   */
+  def depth(p: Producer[P, _]): Option[Int] = depths.get(p)
+  def dependantsOf(p: Producer[P, _]): Option[Set[Producer[P, _]]] = graph.get(p)
+
+  def fanOut(p: Producer[P, _]): Option[Int] = dependantsOf(p).map { _.size }
+}

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Graph.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Graph.scala
@@ -35,6 +35,41 @@ object Producer {
 
   implicit def semigroup[P <: Platform[P], T]: Semigroup[Producer[P, T]] =
     Semigroup.from(_ merge _)
+
+  def dependenciesOf[P <: Platform[P]](p: Producer[P, _]): Set[Producer[P, _]] = {
+    /*
+     * Keyed producers seem to have some issue with type inference that
+     * I work around with the cast.
+     */
+    p match {
+      case NamedProducer(producer, _) => Set(producer)
+      case IdentityKeyedProducer(producer) => Set(producer.asInstanceOf[Producer[P, _]])
+      case Source(source, _) => Set()
+      case OptionMappedProducer(producer, fn, mf) => Set(producer)
+      case FlatMappedProducer(producer, fn) => Set(producer)
+      case MergedProducer(l, r) => Set(l, r)
+      case WrittenProducer(producer, fn) => Set(producer)
+      case LeftJoinedProducer(producer, service) => Set(producer.asInstanceOf[Producer[P, _]])
+      case Summer(producer, store, monoid) => Set(producer.asInstanceOf[Producer[P, _]])
+    }
+  }
+
+  /** Since we know these nodes form a DAG by immutability
+   * the search is easy
+   */
+  def transitiveDependenciesOf[P <: Platform[P]](p: Producer[P, _]): Set[Producer[P, _]] = {
+    @annotation.tailrec
+    def loop(stack: List[Producer[P, _]], acc: Set[Producer[P, _]]): Set[Producer[P, _]] = {
+      stack match {
+        case Nil => acc
+        case h::tail =>
+          val newStack = dependenciesOf(h).filterNot(acc).foldLeft(tail) { (s, it) => it :: s }
+          loop(newStack, acc + h)
+      }
+    }
+    val start = dependenciesOf(p)
+    loop(start.toList, start)
+  }
 }
 
 /**

--- a/summingbird-core/src/test/scala/com/twitter/summingbird/DependantsTests.scala
+++ b/summingbird-core/src/test/scala/com/twitter/summingbird/DependantsTests.scala
@@ -1,0 +1,102 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.summingbird
+
+import com.twitter.summingbird.memory._
+
+import org.scalacheck._
+import Gen._
+import Arbitrary.arbitrary
+import org.scalacheck.Prop._
+
+import scala.collection.mutable.{Map => MMap}
+
+object DependantsTest extends Properties("Dependants") {
+
+  val genSource1 = value(Producer.source[Memory, Int](List[Int]()))
+  val genSource2 = value(IdentityKeyedProducer(Producer.source[Memory, (Int, Int)](List[(Int, Int)]())))
+
+  // Put the non-recursive calls first, otherwise you blow the stack
+  lazy val genOptMap11 = for {
+    fn <- arbitrary[(Int) => Option[Int]]
+    in <- genProd1
+  } yield OptionMappedProducer(in, fn, manifest[Int])
+
+  lazy val genOptMap12 = for {
+    fn <- arbitrary[(Int) => Option[(Int,Int)]]
+    in <- genProd1
+  } yield IdentityKeyedProducer(OptionMappedProducer(in, fn, manifest[(Int, Int)]))
+
+  lazy val genOptMap21 = for {
+    fn <- arbitrary[((Int,Int)) => Option[Int]]
+    in <- genProd2
+  } yield OptionMappedProducer(in, fn, manifest[Int])
+
+  lazy val genOptMap22 = for {
+    fn <- arbitrary[((Int,Int)) => Option[(Int,Int)]]
+    in <- genProd2
+  } yield IdentityKeyedProducer(OptionMappedProducer(in, fn, manifest[(Int, Int)]))
+  // TODO: add more nodes, abstract over Platform
+  lazy val summed = for {
+    in <- genSummable // don't sum sums
+  } yield in.sumByKey(MMap[Int, Int]())
+
+  // We bias towards sources so the trees don't get too deep
+  def genSummable: Gen[KeyedProducer[Memory, Int, Int]] = frequency((2, genSource2), (1, genOptMap12), (1, genOptMap22))
+  def genProd2: Gen[KeyedProducer[Memory, Int, Int]] = frequency((3, genSource2), (1, genOptMap12), (1, genOptMap22), (1, summed))
+  def genProd1: Gen[Producer[Memory, Int]] = frequency((3, genSource1), (1, genOptMap11), (1, genOptMap21))
+
+  implicit def genProducer: Arbitrary[Producer[Memory, _]] = Arbitrary(oneOf(genProd1, genProd2))
+
+  property("transitive deps includes non-transitive") = forAll { (prod: Producer[Memory, _]) =>
+    val deps = Producer.dependenciesOf(prod)
+    (Producer.transitiveDependenciesOf(prod) & deps) == deps
+  }
+  property("we don't depend on ourself") = forAll { (prod: Producer[Memory, _]) =>
+    !((Producer.dependenciesOf(prod) | Producer.transitiveDependenciesOf(prod)).contains(prod))
+  }
+  property("if transitive deps == non-transitive, then parents are sources") = forAll { (prod: Producer[Memory, _]) =>
+    val deps = Producer.dependenciesOf(prod)
+    (Producer.transitiveDependenciesOf(prod) == deps) ==> (deps.forall { case s@Source(_, _) => true; case _ => false })
+  }
+  def implies(a: Boolean, b: => Boolean): Boolean = if (a) b else true
+
+  property("Sources all the only things of depth == 0") = forAll { (prod: Producer[Memory, _]) =>
+    val deps = Dependants(prod)
+    Producer.transitiveDependenciesOf(prod).forall { t =>
+      val tdepth = deps.depth(t).get
+      implies(tdepth == 0, t.isInstanceOf[Source[_, _]]) &&
+      implies(tdepth > 0, (Producer.dependenciesOf(t).map { deps.depth(_).get }.max) < tdepth) &&
+      implies(tdepth > 0, Producer.dependenciesOf(t).exists { deps.depth(_) == Some(tdepth-1) })
+    }
+  }
+
+  property("Tails have max depth") = forAll { (tail: Producer[Memory, _]) =>
+    val deps = Dependants(tail)
+    Producer.transitiveDependenciesOf(tail).forall { t =>
+      deps.depth(t).get < deps.depth(tail).get
+    }
+  }
+
+  property("if A is a dependency of B, then B is a dependant of A") = forAll { (prod:  Producer[Memory, _]) =>
+    val dependants = Dependants(prod)
+    Producer.transitiveDependenciesOf(prod).forall { child =>
+      Producer.dependenciesOf(child).forall { parent => dependants.dependantsOf(parent).get.contains(child) } &&
+        (dependants.fanOut(child).get > 0)
+    } && (dependants.fanOut(prod) == Some(0))
+  }
+}

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/sink/OnlineSink.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/sink/OnlineSink.scala
@@ -31,6 +31,7 @@ trait OnlineSink[-Event] extends (Event => Future[Unit]) {
     * to handle appropriate exceptions here.
     */
   def write(event: Event): Future[Unit]
+  final def apply(e: Event) = write(e)
 }
 
 class EmptyOnlineSink[Event] extends OnlineSink[Event] {


### PR DESCRIPTION
Tests seem pretty robust.

Should be in a position to check for nodes with fanOut > 2, then sort by depth, and then schedule those in order.
