### PR TITLE
Removes old ScaldingService in favor of new

### DIFF
--- a/summingbird-builder/src/main/scala/com/twitter/summingbird/builder/SourceBuilder.scala
+++ b/summingbird-builder/src/main/scala/com/twitter/summingbird/builder/SourceBuilder.scala
@@ -100,8 +100,7 @@ case class SourceBuilder[T: Manifest] private (
       : SourceBuilder[(K, (V, Option[JoinedValue]))] =
     copy(
       node = node.asInstanceOf[Node[(K, V)]].leftJoin(
-        // https://github.com/twitter/summingbird/issues/68,
-        sys.error("TODO"),
+        service.offline,
         StoreWrapper[K, JoinedValue](service.online)
       )
     )

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingService.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingService.scala
@@ -26,6 +26,11 @@ trait ScaldingService[K, V] extends java.io.Serializable {
   def lookup[W](getKeys: PipeFactory[(K, W)]): PipeFactory[(K, (W, Option[V]))]
 }
 
+class EmptyService[K, V] extends ScaldingService[K, V] {
+  def lookup[W](getKeys: PipeFactory[(K, W)]): PipeFactory[(K, (W, Option[V]))] =
+    getKeys.map { _.map { _.map { case (t, (k, v)) => (t, (k, (v, None: Option[V]))) } } }
+}
+
 trait BatchedService[K, V] extends ScaldingService[K, V] {
   // The batcher that describes this service
   def batcher: Batcher


### PR DESCRIPTION
Breaking, but the impedance mismatch was just too much. We can redo the existing internal services to match the new API.
