### PR TITLE
Cast in evToKeyed

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Graph.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Graph.scala
@@ -32,7 +32,7 @@ object Producer {
 
   implicit def evToKeyed[P <: Platform[P], T, K, V](producer: Producer[P, T])
     (implicit ev: T <:< (K, V)): KeyedProducer[P, K, V] =
-    IdentityKeyedProducer[P, K, V](producer)
+    IdentityKeyedProducer[P, K, V](producer.asInstanceOf[Producer[P, (K, V)]])
 
   implicit def toKeyed[P <: Platform[P], K, V](producer: Producer[P, (K, V)]): KeyedProducer[P, K, V] =
     IdentityKeyedProducer[P, K, V](producer)


### PR DESCRIPTION
Without this, we found a cycle (since the inner producer was implicitly converted over and over.)
