### PR TITLE
example: move storm jobname to match new method signatures

### DIFF
--- a/summingbird-example/src/main/scala/com/twitter/summingbird/example/StormRunner.scala
+++ b/summingbird-example/src/main/scala/com/twitter/summingbird/example/StormRunner.scala
@@ -88,8 +88,9 @@ object StormRunner {
     * locally.)
     */
   def main(args: Array[String]) {
-    Storm.local("wordCountJob").run(
-      wordCount[Storm](spout, storeSupplier)
+    Storm.local().run(
+      wordCount[Storm](spout, storeSupplier),
+      "wordCountJob"
     )
   }
   /**


### PR DESCRIPTION
Commit 2fc086ac (Fix storm testing situation) updated
storm initialization idiom from

Storm.local(jobname, opts).run(foo)

to

Storm.local(opts).run(foo, jobname)

This commit updates StormRunner in the example code to these new
method signatures so that the summingbird-example project builds
successfully.
