### PR TITLE
Change depthFirstOf to use List instead of Vector

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Producer.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Producer.scala
@@ -31,7 +31,7 @@ object Producer {
         case _ => dependenciesOf(in)
       }
     }
-    val above = graph.depthFirstOf(p)(parentFn).toList
+    val above = graph.depthFirstOf(p)(parentFn)
     p :: above
   }
 
@@ -74,7 +74,7 @@ object Producer {
    */
   def transitiveDependenciesOf[P <: Platform[P]](p: Producer[P, Any]): List[Producer[P, Any]] = {
     val nfn = dependenciesOf[P](_)
-    graph.depthFirstOf(p)(nfn).toList
+    graph.depthFirstOf(p)(nfn)
   }
 }
 

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/graph/DependantGraph.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/graph/DependantGraph.scala
@@ -46,5 +46,5 @@ abstract class DependantGraph[T] {
    * Return all dependendants of a given node.
    * Does not include itself
    */
-  def transitiveDependantsOf(p: T): List[T] = depthFirstOf(p)(graph).toList
+  def transitiveDependantsOf(p: T): List[T] = depthFirstOf(p)(graph)
 }

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
@@ -22,19 +22,19 @@ package object graph {
 
   /** Return the depth first enumeration of reachable nodes,
    * NOT INCLUDING INPUT, unless it can be reached via neighbors */
-  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): IndexedSeq[T] = {
+  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): List[T] = {
     @annotation.tailrec
-    def loop(stack: List[T], deps: Vector[T], acc: Set[T]): (Vector[T], Set[T]) = {
+    def loop(stack: List[T], deps: List[T], acc: Set[T]): List[T] = {
       stack match {
-        case Nil => (deps, acc)
+        case Nil => deps
         case h::tail =>
           val newStack = nf(h).filterNot(acc).foldLeft(tail) { (s, it) => it :: s }
-          val newDeps = if(acc(h)) deps else (deps :+ h)
+          val newDeps = if (acc(h)) deps else h :: deps
           loop(newStack, newDeps, acc + h)
       }
     }
-    val start = nf(t)
-    loop(start.toList, Vector(start.toSeq.distinct : _*), start.toSet)._1
+    val start = nf(t).toList
+    loop(start, start.distinct, start.toSet).reverse
   }
 
   /** Return a NeighborFn for the graph of reversed edges defined by


### PR DESCRIPTION
I noticed that `depthFirstOf` is always called with a `toList` following it. I performed a quick Thyme benchmark between using `Vector` for appends vs. constructing a `List` and finally calling `.reverse` on it:

``` scala
scala> th.pbench { (0 to 1000).foldLeft(List.empty[Int]) { case (xs, i) => i :: xs }.reverse }
Benchmark (163820 calls in 4.485 s)
  Time:    20.60 us   95% CI 19.58 us - 21.62 us   (n=20)
  Garbage: 6.519 us   (n=423 sweeps measured)

scala> th.pbench { (0 to 1000).foldLeft(Vector.empty[Int]) { case (v, i) => v :+ i } }
Benchmark (81900 calls in 4.628 s)
  Time:    42.28 us   95% CI 40.25 us - 44.31 us   (n=20)
  Garbage: 13.65 us   (n=580 sweeps measured)
```

Also, later calling `toList` on the `Vector` is probably not very cheap. I am not sure how often `depthFirstOf` gets called in typical summingbird workflows, but I figured it couldn't hurt. summingbird-core tests pass on my machine with these updates.
