### PR TITLE
Null out Tuple.values for GC

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/AsyncBaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/AsyncBaseBolt.scala
@@ -100,7 +100,7 @@ abstract class AsyncBaseBolt[I, O](metrics: () => TraversableOnce[StormMetric[_]
   /** This is clearly not safe, but done to deal with GC issues since
    * storm keeps references to values
    */
-  private val valuesField = {
+  private lazy val valuesField = {
     val tupleClass = classOf[TupleImpl]
     val vf = tupleClass.getDeclaredField("values")
     vf.setAccessible(true)


### PR DESCRIPTION
The recent change seems to be cranking GC up to crisis on some nodes. This seems safe according to @jasonjckn so let's see if this solves the issue.
