### PR TITLE
Fix README to properly run Storm locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ lazy val config = new ConfigurationBuilder()
 You're all ready to go! Now it's time to unleash Storm on your Twitter stream. Make sure the `memcached` terminal is still open, then start Storm from the `summingbird` directory:
 
 ```bash
-./sbt summingbird-example/run
+./sbt "summingbird-example/run --local"
 ```
 
 Storm should puke out a bunch of output, then stabilize and hang. This means that Storm is updating your local memcache instance with counts of every word that it sees in each tweet.


### PR DESCRIPTION
The README to set up summingbird-example will not run Storm locally, and will result in some failure output. Updating the README to properly run Storm in local mode in the tutorial.
