### PR TITLE
Make Commutativity settings a case object

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/option/Commutativity.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/option/Commutativity.scala
@@ -18,15 +18,11 @@ package com.twitter.summingbird.option
 
 import java.io.Serializable
 
-trait BasicPrint {
-  override def toString = getClass.getName
-}
-
 // TODO: this functionality should be in algebird:
 // https://github.com/twitter/algebird/issues/128
-sealed trait Commutativity extends Serializable with BasicPrint
-object NonCommutative extends Commutativity
-object Commutative extends Commutativity
+sealed trait Commutativity extends Serializable
+case object NonCommutative extends Commutativity
+case object Commutative extends Commutativity
 
 /** A readable way to specify commutivity in a way
  * that works with the Class-based Options system.


### PR DESCRIPTION
This gives us things like a cleaner toString and what-have-you for free
