### PR TITLE
This refactors time out of several places inside the online code. Allows...

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -16,7 +16,6 @@ limitations under the License.
 
 package com.twitter.summingbird.online.executor
 
-import com.twitter.summingbird.batch.Timestamp
 import com.twitter.summingbird.online.Queue
 import com.twitter.summingbird.online.option.{MaxWaitingFutures, MaxFutureWaitTime, MaxEmitPerExecute}
 import com.twitter.util.{Await, Duration, Future}
@@ -33,27 +32,27 @@ abstract class AsyncBase[I,O,S,D](maxWaitingFutures: MaxWaitingFutures, maxWaiti
    * cases that need to complete operations after or before doing a FlatMapOperation or
    * doing a store merge
    */
-  def apply(state: S, in: (Timestamp, I)): Future[Iterable[(List[S], Future[TraversableOnce[(Timestamp, O)]])]]
-  def tick: Future[Iterable[(List[S], Future[TraversableOnce[(Timestamp, O)]])]] = Future.value(Nil)
+  def apply(state: S, in: I): Future[TraversableOnce[(List[S], Future[TraversableOnce[O]])]]
+  def tick: Future[TraversableOnce[(List[S], Future[TraversableOnce[O]])]] = Future.value(Nil)
 
   private lazy val outstandingFutures = Queue.linkedNonBlocking[Future[Unit]]
-  private lazy val responses = Queue.linkedNonBlocking[(List[S], Try[TraversableOnce[(Timestamp, O)]])]
+  private lazy val responses = Queue.linkedNonBlocking[(List[S], Try[TraversableOnce[O]])]
 
   override def executeTick =
     finishExecute(tick.onFailure{ thr => responses.put(((List(), Failure(thr)))) })
 
-  override def execute(state: S, data: (Timestamp, I)) =
+  override def execute(state: S, data: I) =
     finishExecute(apply(state, data).onFailure { thr => responses.put(((List(state), Failure(thr)))) })
 
-  private def finishExecute(fIn: Future[Iterable[(List[S], Future[TraversableOnce[(Timestamp, O)]])]]) = {
+  private def finishExecute(fIn: Future[TraversableOnce[(List[S], Future[TraversableOnce[O]])]]) = {
     addOutstandingFuture(handleSuccess(fIn).unit)
 
     // always empty the responses
     emptyQueue
   }
 
-  private def handleSuccess(fut: Future[Iterable[(List[S], Future[TraversableOnce[(Timestamp, O)]])]]) =
-    fut.onSuccess { iter: Iterable[(List[S], Future[TraversableOnce[(Timestamp, O)]])] =>
+  private def handleSuccess(fut: Future[TraversableOnce[(List[S], Future[TraversableOnce[O]])]]) =
+    fut.onSuccess { iter: TraversableOnce[(List[S], Future[TraversableOnce[O]])] =>
 
         // Collect the result onto our responses
         val iterSize = iter.foldLeft(0) { case (iterSize, (tups, res)) =>

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -36,7 +36,7 @@ class IntermediateFlatMap[T,U,S,D](
   maxEmitPerExec: MaxEmitPerExecute,
   pDecoder: Injection[(Timestamp, T), D],
   pEncoder: Injection[(Timestamp, U), D]
-  ) extends AsyncBase[T,U,S,D](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
+  ) extends AsyncBase[(Timestamp, T), (Timestamp, U), S, D](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
 
   val encoder = pEncoder
   val decoder = pDecoder

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -21,12 +21,12 @@ import com.twitter.bijection.Injection
 import com.twitter.summingbird.batch.Timestamp
 
 trait OperationContainer[Input, Output, State, WireFmt] {
-  def decoder: Injection[(Timestamp, Input), WireFmt]
-  def encoder: Injection[(Timestamp, Output), WireFmt]
-  def executeTick: TraversableOnce[(List[State], Try[TraversableOnce[(Timestamp, Output)]])]
+  def decoder: Injection[Input, WireFmt]
+  def encoder: Injection[Output, WireFmt]
+  def executeTick: TraversableOnce[(List[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
-              data: (Timestamp, Input)):
-               TraversableOnce[(List[State], Try[TraversableOnce[(Timestamp, Output)]])]
+              data: Input):
+               TraversableOnce[(List[State], Try[TraversableOnce[Output]])]
   def init {}
   def cleanup {}
   def notifyFailure(inputs: List[State], e: Throwable) {}

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -59,9 +59,9 @@ class Summer[Key, Value: Semigroup, S, D](
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
   includeSuccessHandler: IncludeSuccessHandler,
-  pDecoder: Injection[(Timestamp, ((Key, BatchID), Value)), D],
+  pDecoder: Injection[((Key, BatchID), (Timestamp, Value)), D],
   pEncoder: Injection[(Timestamp, (Key, (Option[Value], Value))), D]) extends
-    AsyncBase[((Key, BatchID), Value), (Key, (Option[Value], Value)), S, D](
+    AsyncBase[((Key, BatchID), (Timestamp, Value)), (Timestamp, (Key, (Option[Value], Value))), S, D](
       maxWaitingFutures,
       maxWaitingTime,
       maxEmitPerExec) {
@@ -104,8 +104,8 @@ class Summer[Key, Value: Semigroup, S, D](
   override def tick = sCache.tick.map(handleResult(_))
 
   override def apply(state: S,
-                     tsIn: (Timestamp, ((Key, BatchID), Value))) = {
-    val (ts, (kb, v)) = tsIn
+                     tsIn: ((Key, BatchID), (Timestamp, Value))) = {
+    val (kb, (ts, v)) = tsIn
     sCache.insert(List(kb -> (List(state), ts, v))).map(handleResult(_))
   }
 

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/InjectionLaws.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/InjectionLaws.scala
@@ -27,11 +27,11 @@ object InjectionLaws extends Properties("InjectionTests") {
   implicit def ts: Arbitrary[Timestamp] =
     Arbitrary(Arbitrary.arbitrary[Long].map(Timestamp(_)))
 
-  property("Single injection works") = forAll { in: (Timestamp, String) =>
+  property("Single injection works") = forAll { in: String =>
     val inj = new SingleItemInjection[String]
     inj.invert(inj(in)).get == in
   }
-  property("KV injection works") = forAll { in: (Timestamp, (String, List[Int])) =>
+  property("KV injection works") = forAll { in: (String, List[Int]) =>
     val inj = new KeyValueInjection[String, List[Int]]
     inj.invert(inj(in)).get == in
   }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -25,7 +25,6 @@ import backtype.storm.tuple.{Tuple, TupleImpl, Fields}
 
 import java.util.{ Map => JMap }
 
-import com.twitter.summingbird.batch.Timestamp
 import com.twitter.summingbird.storm.option.{AckOnEntry, AnchorTuples, MaxWaitingFutures}
 import com.twitter.summingbird.online.executor.OperationContainer
 import com.twitter.summingbird.online.executor.{InflightTuples, InputState}
@@ -95,7 +94,7 @@ case class BaseBolt[I,O](metrics: () => TraversableOnce[StormMetric[_]],
     }
   }
 
-  private def finish(inputs: List[InputState[Tuple]], results: TraversableOnce[(Timestamp, O)]) {
+  private def finish(inputs: List[InputState[Tuple]], results: TraversableOnce[O]) {
     var emitCount = 0
     if(hasDependants) {
       if(anchorTuples.anchor) {

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -249,8 +249,8 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
             maxWaiting,
             maxWaitTime,
             maxEmitPerExecute,
-            new SingleItemInjection[Any],
-            new KeyValueInjection[(Any, BatchID), Any]
+            new SingleItemInjection[(Timestamp, Any)],
+            new KeyValueInjection[(Any, BatchID), (Timestamp, Any)]
             )(summerProducer.monoid.asInstanceOf[Monoid[Any]], summerProducer.store.batcher)
             )
       case None =>
@@ -265,8 +265,8 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
             maxWaiting,
             maxWaitTime,
             maxEmitPerExecute,
-            new SingleItemInjection[Any],
-            new SingleItemInjection[Any]
+            new SingleItemInjection[(Timestamp, Any)],
+            new SingleItemInjection[(Timestamp, Any)]
             )
           )
     }
@@ -365,8 +365,8 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
               getOrElse(stormDag, node, DEFAULT_MAX_FUTURE_WAIT_TIME),
               maxEmitPerExecute,
               getOrElse(stormDag, node, IncludeSuccessHandler.default),
-              new KeyValueInjection[(K,BatchID), V],
-              new SingleItemInjection[(K, (Option[V], V))])
+              new KeyValueInjection[(K, BatchID), (Timestamp, V)],
+              new SingleItemInjection[(Timestamp, (K, (Option[V], V)))])
         )
 
     val parallelism = getOrElse(stormDag, node, DEFAULT_SUMMER_PARALLELISM).parHint

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/TupleInjections.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/TupleInjections.scala
@@ -18,37 +18,36 @@ package com.twitter.summingbird.storm
 
 
 import com.twitter.bijection.{Injection, Inversion, AbstractInjection}
-import com.twitter.summingbird.batch.Timestamp
 import java.util.{List => JList, ArrayList => JAList}
 import scala.util.Try
 
-class SingleItemInjection[T] extends Injection[(Timestamp, T), JList[AnyRef]] {
+class SingleItemInjection[T] extends Injection[T, JList[AnyRef]] {
 
-  override def apply(t: (Timestamp, T)) = {
+  override def apply(t: T) = {
     val list = new JAList[AnyRef](1)
-    list.add(t)
+    list.add(t.asInstanceOf[AnyRef])
     list
   }
 
   override def invert(vin: JList[AnyRef]) = Inversion.attempt(vin) { v =>
-    v.get(0).asInstanceOf[(Timestamp, T)]
+    v.get(0).asInstanceOf[T]
   }
 }
 
 class KeyValueInjection[K, V]
-  extends Injection[(Timestamp, (K, V)), JList[AnyRef]] {
+  extends Injection[(K, V), JList[AnyRef]] {
 
-  override def apply(item: (Timestamp, (K, V))) = {
-    val (ts, (key, v)) = item
+  override def apply(item: (K, V)) = {
+    val (key, v) = item
     val list = new JAList[AnyRef](2)
     list.add(key.asInstanceOf[AnyRef])
-    list.add((ts, v))
+    list.add(v.asInstanceOf[AnyRef])
     list
   }
 
   override def invert(vin: JList[AnyRef]) = Inversion.attempt(vin) { v =>
     val key = v.get(0).asInstanceOf[K]
-    val (ts, value) = v.get(1).asInstanceOf[(Timestamp, V)]
-    (ts, (key, value))
+    val value = v.get(1).asInstanceOf[V]
+    (key, value)
   }
 }


### PR DESCRIPTION
... more flexibility as to what we pass around between nodes

Just removing Timestamp from being places it doesn't seem it should/needs to be.
