### PR TITLE
Fixes bug that meant storm tests weren't running

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -116,6 +116,7 @@ object SummingbirdBuild extends Build {
     summingbirdOnline,
     summingbirdClient,
     summingbirdStorm,
+    summingbirdStormTest,
     summingbirdScalding,
     summingbirdScaldingTest,
     summingbirdBuilder,

--- a/summingbird-storm-test/src/main/scala/com/twitter/summingbird/storm/StormTestRun.scala
+++ b/summingbird-storm-test/src/main/scala/com/twitter/summingbird/storm/StormTestRun.scala
@@ -67,8 +67,9 @@ object StormTestRun {
     try {
       val cluster = new LocalCluster()
       cluster.submitTopology("test topology", plannedTopology.config, plannedTopology.topology)
-      // Sleep to prevent this race: https://github.com/nathanmarz/storm/pull/667
       Thread.sleep(4000)
+      cluster.killTopology("test topology")
+      Thread.sleep(1000)
       cluster.shutdown
     } finally {
       System.setSecurityManager(oldSecManager)


### PR DESCRIPTION
Sigh, my usual mistake. Didn't add the storm-test to the aggregate target so it wasn't being tested.

Also had some failures without the other sleep/kill in a few runs. With these settings it seems stable.
