### PR TITLE
Vagrant folder added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ project/plugins/src_managed/
 */.settings
 */.cache
 */.classpath
+vagrant/


### PR DESCRIPTION
I'm working through [issue 212](https://github.com/twitter/summingbird/issues/212), and realized I had changed the gitignore file to use my Vagrant workflow.  I wasn't sure if y'all wanted such a trivial change as its own PR, a separate commit in a PR, or buried in another commit since this change is side effect.  The contributing lists "small simple changes" per commit, so I thought I'd just open a PR and ask just to be safe.
