### PR TITLE
fix unidoc target

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/SummerOptions.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/SummerOptions.scala
@@ -29,7 +29,6 @@ import com.twitter.util.Duration
   */
 
 
-
 /**
   * SinkParallelism controls the number of executors storm allocates to
   * the groupAndSum bolts. Each of these bolt executors is responsible
@@ -38,22 +37,6 @@ import com.twitter.util.Duration
   * the store. The default sink parallelism is 5.
   */
 case class SummerParallelism(parHint: Int)
-
-// case class OnlineSuccessHandler(handlerFn: Unit => Unit)
-
-/**
-  * Kryo serialization problems have been observed with using
-  * OnlineSuccessHandler. This enables easy disabling of the handler.
-  * TODO (https://github.com/twitter/summingbird/issues/82): remove
-  * once we know what the hell is going on with this
-  */
-// case class IncludeSuccessHandler(get: Boolean)
-
-// object IncludeSuccessHandler {
-//   val default = IncludeSuccessHandler(true)
-// }
-
-// case class OnlineExceptionHandler(handlerFn: PartialFunction[Throwable, Unit])
 
 /**
   * See FlatMapOptions.scala for an explanation.


### PR DESCRIPTION
The ./sbt unidoc target is failing with errors like

[error] /Users/fkaelin/workspace/github/summingbird/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/SummerOptions.scala:42: OnlineSuccessHandler is already defined as value OnlineSuccessHandler
[error] case class OnlineSuccessHandler(handlerFn: Unit => Unit)

There are duplicate type definitions in the online and storm packages, which compiles fine due to shadowing but the docs don't seem to like that. With this change the unidoc target succeeds (I want/need it as I use Dash for documentation browsing)

Not sure this is the right way to go about it, ./sbt test failed with a java.lang.OutOfMemoryError: Java heap space. There is also duplicate code in https://github.com/twitter/summingbird/blob/cbfb833e78fd6434bc1cfe18ce0696e8cf527bee/summingbird-builder/src/main/scala/com/twitter/summingbird/builder/package.scala#L66 that points to the storm options I am deleting - which makes me wonder why ./sbt compile still succeeds. 
