### PR TITLE
Add/use the multiplier option

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Constants.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Constants.scala
@@ -52,4 +52,5 @@ object Constants {
   val DEFAULT_VALUE_COMBINER_CACHE_SIZE = ValueCombinerCacheSize(100)
   val DEFAULT_ACK_ON_ENTRY = AckOnEntry(false)
   val DEFAULT_MAX_EMIT_PER_EXECUTE = MaxEmitPerExecute(Int.MaxValue)
+  val DEFAULT_SUMMER_BATCH_MULTIPLIER = SummerBatchMultiplier(1)
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
@@ -143,9 +143,10 @@ case class FlatMapBoltProvider(storm: Storm, stormDag: Dag[Storm], node: StormNo
     // Query to get the summer paralellism of the summer down stream of us we are emitting to
     // to ensure no edge case between what we might see for its parallelism and what it would see/pass to storm.
     val summerParalellism = getOrElse(DEFAULT_SUMMER_PARALLELISM, summer)
+    val summerBatchMultiplier = getOrElse(DEFAULT_SUMMER_BATCH_MULTIPLIER, summer)
 
     // This option we report its value here, but its not user settable.
-    val keyValueShards = executor.KeyValueShards(summerParalellism.parHint)
+    val keyValueShards = executor.KeyValueShards(summerParalellism.parHint * summerBatchMultiplier.get)
     logger.info("[{}] keyValueShards : {}", nodeName, keyValueShards.get)
 
     val operation = foldOperations[T, (K, V)](node.members.reverse)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/SummerOptions.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/SummerOptions.scala
@@ -46,3 +46,6 @@ object SummerStormMetrics {
   def unapply(metrics: SummerStormMetrics) = Some(metrics.metrics)
 }
 class SummerStormMetrics(val metrics: () => TraversableOnce[StormMetric[_]])
+
+
+case class SummerBatchMultiplier(get: Int)


### PR DESCRIPTION
This gets around the issue we've seen of the batches being able to overwhelm stores that can't handle large data bursts
