### PR TITLE
smoketest displaying error running example

### DIFF
--- a/summingbird-example/src/test/scala/com/twitter/summingbird/example/SmokeTest.scala
+++ b/summingbird-example/src/test/scala/com/twitter/summingbird/example/SmokeTest.scala
@@ -1,0 +1,14 @@
+package com.twitter.summingbird.example
+
+import org.specs2.mutable._
+
+class Smoketest extends Specification {
+
+  "The memcache storage" should {
+    "be able to be created" in {
+      val stringLongStore =
+        Memcache.mergeable[String, Long]("urlCount")
+      1 must beEqualTo(1)
+    }
+  }
+}


### PR DESCRIPTION
Currently, I get this failure trying to run the example:

java.lang.NoSuchMethodError: com.twitter.concurrent.Spool$.syntax(Lcom/twitter/util/Future;)Lcom/twitter/concurrent/Spool$Syntax;
