### PR TITLE
Fixing tormentaSpout.registerMetric call in scheduleSpout 

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -216,9 +216,8 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
     }
 
     val metrics = getOrElse(stormDag, node, DEFAULT_SPOUT_STORM_METRICS)
-    tormentaSpout.registerMetrics(metrics.toSpoutMetrics)
 
-    val stormSpout = tormentaSpout.getSpout
+    val stormSpout = tormentaSpout.registerMetrics(metrics.toSpoutMetrics).getSpout
     val parallelism = getOrElse(stormDag, node, parOpt.getOrElse(DEFAULT_SPOUT_PARALLELISM)).parHint
     topologyBuilder.setSpout(nodeName, stormSpout, parallelism)
   }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/FlatMapOptions.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/option/FlatMapOptions.scala
@@ -16,9 +16,10 @@ limitations under the License.
 
 package com.twitter.summingbird.storm.option
 
-import com.twitter.summingbird.storm.StormMetric
 import backtype.storm.metric.api.IMetric
+import com.twitter.summingbird.storm.StormMetric
 import com.twitter.tormenta.spout.Metric
+import java.io.Serializable
 
 /**
  * Options used by the flatMapping stage of a storm topology.
@@ -56,7 +57,7 @@ object SpoutStormMetrics {
   def unapply(metrics: SpoutStormMetrics) = Some(metrics.metrics)
 }
 
-class SpoutStormMetrics(val metrics: () => TraversableOnce[StormMetric[IMetric]]) {
+class SpoutStormMetrics(val metrics: () => TraversableOnce[StormMetric[IMetric]]) extends Serializable {
   def toSpoutMetrics: () => TraversableOnce[Metric[IMetric]] =
     { () => metrics().map { x: StormMetric[IMetric] => Metric(x.name, x.metric, x.interval.inSeconds) } }
 }


### PR DESCRIPTION
to use the returned value
