### PR TITLE
BatchedStore unit test using one batch

### DIFF
--- a/summingbird-scalding-test/src/main/scala/com/twitter/summingbird/scalding/TestUtil.scala
+++ b/summingbird-scalding-test/src/main/scala/com/twitter/summingbird/scalding/TestUtil.scala
@@ -75,6 +75,20 @@ object TestUtil {
     else randomBatcher(items.iterator.map(_._1).min, items.iterator.map(_._1).max)
   }
 
+  def singleBatchBatcher(items: Iterable[(Long, Any)]): Batcher = {
+    if (items.isEmpty) simpleBatcher
+    else singleBatchBatcher(items.iterator.map(_._1).min, items.iterator.map(_._1).max)
+  }
+
+  def singleBatchBatcher(mintimeInc: Long, maxtimeInc: Long): Batcher = { //simpleBatcher
+    // we can have between 1 and (maxtime - mintime + 1) batches.
+    val delta = (maxtimeInc - mintimeInc)
+    val MaxBatches = 5L min delta
+    val batches = 1L // have one batch
+    val timePerBatch = (delta + 1L) / batches
+    new MillisecondBatcher(timePerBatch)
+  }
+
   def randomBatcher(mintimeInc: Long, maxtimeInc: Long): Batcher = { //simpleBatcher
     // we can have between 1 and (maxtime - mintime + 1) batches.
     val delta = (maxtimeInc - mintimeInc)


### PR DESCRIPTION
Attempting to repro #567, however this test passes. @zyzheng can you take a look? Is this what you do in your job? If not, could you please suggest modifications to repro the case? Do you start with an empty store or with some content in your store?

I ran an internal test using one of our production jobs, the test passes for summingbird-scalding so the bug is not immediately obvious. 
