### PR TITLE
Pass the reducers option down to leftJoin

### DIFF
--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
@@ -387,9 +387,10 @@ object Scalding {
               val (logPf, m2) = recurse(storeLog, built = m1, forceFanOut = true)
               // We have to combine the last snapshot on disk with the deltas:
               val allDeltas: PipeFactory[(K, V)] = bstore.readDeltaLog(logPf)
+              val reducers = getOrElse(options, names, ljp, Reducers.default).count
               val res = for {
                 leftAndDelta <- leftPf.join(allDeltas)
-                joined = InternalService.doIndependentJoin[K, U, V](leftAndDelta._1, leftAndDelta._2, sg)
+                joined = InternalService.doIndependentJoin[K, U, V](leftAndDelta._1, leftAndDelta._2, sg, Some(reducers))
                 // read the latest state, which is the (time interval, mode)
                 maxAvailable <- StateWithError.getState
               } yield Scalding.limitTimes(maxAvailable._1, joined)

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/Service.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/Service.scala
@@ -127,12 +127,13 @@ private[scalding] object InternalService {
    */
   def doIndependentJoin[K: Ordering, U, V](input: FlowToPipe[(K, U)],
     toJoin: FlowToPipe[(K, V)],
-    sg: Semigroup[V]): FlowToPipe[(K, (U, Option[V]))] =
+    sg: Semigroup[V],
+    reducers: Option[Int]): FlowToPipe[(K, (U, Option[V]))] =
 
     Reader[FlowInput, KeyValuePipe[K, (U, Option[V])]] { (flowMode: (FlowDef, Mode)) =>
       val left = input(flowMode)
       val right = toJoin(flowMode)
-      LookupJoin.rightSumming(left, right)(implicitly, implicitly, sg)
+      LookupJoin.rightSumming(left, right, reducers)(implicitly, implicitly, sg)
     }
 
   /**


### PR DESCRIPTION
Looks like we did not pass this option down to doIndependentJoin so the reducers were always set to default.