### PR TITLE
IdentityKeyedProducer in ValueFlatMapToFlatMap  Dag Optimizer rule

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/planner/DagOptimizer.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/planner/DagOptimizer.scala
@@ -291,7 +291,7 @@ trait DagOptimizer[P <: Platform[P]] {
       // TODO: we need to case class here to not lose the irreducible which may be named
       case ValueFlatMappedProducer(in, fn) =>
         // we know that (K, V) <: T due to the case match, but scala can't see it
-        def cast[K, V](p: Prod[(K, V)]): Prod[T] = p.asInstanceOf[Prod[T]]
+        def cast[K, V](p: Prod[(K, V)]): Prod[T] = IdentityKeyedProducer[P, K, V](p).asInstanceOf[Prod[T]]
         cast(in.flatMap { case (k, v) => fn(v).map((k, _)) })
     }
   }

--- a/summingbird-core/src/test/scala/com/twitter/summingbird/TestGraphs.scala
+++ b/summingbird-core/src/test/scala/com/twitter/summingbird/TestGraphs.scala
@@ -338,18 +338,6 @@ object TestGraphs {
       .sumByKey(storeAndService)
   }
 
-  def leftJoinWithDependentStoreJobMap[P <: Platform[P], T, V1, U, K, V: Monoid](
-    source1: Producer[P, T],
-    storeAndService: P#Store[K, V] with P#Service[K, V])(simpleM1: T => (K, U))(valuesMap1: ((U, Option[V])) => V1)(valuesMap2: (V1) => V): TailProducer[P, (K, (Option[V], V))] = {
-
-    source1
-      .map(simpleM1)
-      .leftJoin(storeAndService)
-      .mapValues(valuesMap1)
-      .mapValues(valuesMap2)
-      .sumByKey(storeAndService)
-  }
-
   def leftJoinWithDependentStoreJoinFanoutInScala[T, U, K: Ordering, V: Monoid, V1: Monoid](source: TraversableOnce[T])(simpleFM: T => TraversableOnce[(Long, (K, U))])(flatMapValuesFn: ((Long, (U, Option[V]))) => TraversableOnce[(Long, V)])(flatMapFn: ((Long, (K, (U, Option[V])))) => TraversableOnce[(Long, (K, V1))]): (Map[K, V], Map[K, V1]) = {
 
     // zip the left and right streams

--- a/summingbird-core/src/test/scala/com/twitter/summingbird/TestGraphs.scala
+++ b/summingbird-core/src/test/scala/com/twitter/summingbird/TestGraphs.scala
@@ -193,6 +193,26 @@ object TestGraphs {
       .flatMap(postJoinFn)
       .sumByKey(store)
 
+  def leftJoinWithFlatMapValuesInScala[T, U, JoinedU, K, V: Monoid](source: TraversableOnce[T])(service: K => Option[JoinedU])(preJoinFn: T => TraversableOnce[(K, U)])(postJoinFn: ((U, Option[JoinedU])) => TraversableOnce[V]): Map[K, V] =
+    MapAlgebra.sumByKey(
+      source
+        .flatMap(preJoinFn)
+        .map { case (k, v) => (k, (v, service(k))) }
+        .flatMap { case (k, v) => postJoinFn(v).map { v => (k, v) } }
+    )
+
+  def leftJoinJobWithFlatMapValues[P <: Platform[P], T, U, JoinedU, K, V: Monoid](
+    source: Producer[P, T],
+    service: P#Service[K, JoinedU],
+    store: P#Store[K, V])(preJoinFn: T => TraversableOnce[(K, U)])(postJoinFn: ((U, Option[JoinedU])) => TraversableOnce[V]): TailProducer[P, (K, (Option[V], V))] =
+    source
+      .name("My named source")
+      .flatMap(preJoinFn)
+      .leftJoin(service)
+      .name("My named flatmap")
+      .flatMapValues(postJoinFn)
+      .sumByKey(store)
+
   def leftJoinWithStoreInScala[T1, T2, U, JoinedU: Monoid, K: Ordering, V: Monoid](source1: TraversableOnce[T1], source2: TraversableOnce[T2])(simpleFM1: T1 => TraversableOnce[(Long, (K, JoinedU))])(simpleFM2: T2 => TraversableOnce[(Long, (K, U))])(postJoinFn: ((Long, (K, (U, Option[JoinedU])))) => TraversableOnce[(Long, (K, V))]): (Map[K, JoinedU], Map[K, V]) = {
 
     val firstStore = MapAlgebra.sumByKey(
@@ -315,6 +335,18 @@ object TestGraphs {
       .leftJoin(storeAndService)
       .flatMapValues(valuesFlatMap1)
       .flatMapValues(valuesFlatMap2)
+      .sumByKey(storeAndService)
+  }
+
+  def leftJoinWithDependentStoreJobMap[P <: Platform[P], T, V1, U, K, V: Monoid](
+    source1: Producer[P, T],
+    storeAndService: P#Store[K, V] with P#Service[K, V])(simpleM1: T => (K, U))(valuesMap1: ((U, Option[V])) => V1)(valuesMap2: (V1) => V): TailProducer[P, (K, (Option[V], V))] = {
+
+    source1
+      .map(simpleM1)
+      .leftJoin(storeAndService)
+      .mapValues(valuesMap1)
+      .mapValues(valuesMap2)
       .sumByKey(storeAndService)
   }
 


### PR DESCRIPTION
We were downcasting ValueFlatMappedProducer to FlatMappedProducer in the ValueFlatMapToFlatMap DagOptimizer rule thus causing ClassCastExceptions when trying to cast to a KeyedProducer during planning. This wraps the cast in an IdentityKeyedProducer to preserve the fact that this is a KeyedProducer. Adds a test as well. 