### PR TITLE
Remove StripNameNodes

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Irreducible.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Irreducible.scala
@@ -1,0 +1,36 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.summingbird
+
+import com.twitter.algebird.{ Semigroup => AlgebirdSemigroup }
+
+/**
+ * An Irreducible is something that was passed from the user
+ * which we cannot look inside of: a source, a function, store,
+ * service, sink.
+ */
+sealed trait Irreducible[P <: Platform[P]]
+
+object Irreducible {
+  // Namespace these since they use common names:
+  case class Source[P <: Platform[P]](source: P#Source[_]) extends Irreducible[P]
+  case class Store[P <: Platform[P]](store: P#Store[_, _]) extends Irreducible[P]
+  case class Sink[P <: Platform[P]](sink: P#Sink[_]) extends Irreducible[P]
+  case class Service[P <: Platform[P]](service: P#Service[_, _]) extends Irreducible[P]
+  case class Function[P <: Platform[P]](fn: Function1[_, _]) extends Irreducible[P]
+  case class Semigroup[P <: Platform[P]](sg: AlgebirdSemigroup[_]) extends Irreducible[P]
+}

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/planner/ComposedFunctions.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/planner/ComposedFunctions.scala
@@ -17,32 +17,6 @@
 package com.twitter.summingbird.planner
 
 /**
- * This is a marker trait that indicates that
- * the subclass holds one or more irreducible
- * items passed by the user. These may need to
- * be accessed at some planning stage after
- * optimization in order to attach the correct
- * options
- */
-trait IrreducibleContainer {
-  def irreducibles: Iterable[Any]
-}
-
-object IrreducibleContainer {
-  def flatten(item: Any): Iterable[Any] = item match {
-    case (ic: IrreducibleContainer) => ic.irreducibles
-    case _ => Seq(item)
-  }
-
-  def flatten(left: Any, right: Any): Iterable[Any] = (left, right) match {
-    case (li: IrreducibleContainer, ri: IrreducibleContainer) => li.irreducibles ++ ri.irreducibles
-    case (li: IrreducibleContainer, _) => Seq(right) ++ li.irreducibles
-    case (_, ri: IrreducibleContainer) => Seq(left) ++ ri.irreducibles
-    case _ => Seq(left, right)
-  }
-}
-
-/**
  * When optimizing and composing flatMaps, this class can be used
  * so that we can recover the parts if needed. For instance,
  * options apply to the irreducible inputs from the user (such as
@@ -50,41 +24,41 @@ object IrreducibleContainer {
  * irreducibiles even after optimization
  */
 case class ComposedFlatMap[A, B, C](first: A => TraversableOnce[B],
-    second: B => TraversableOnce[C]) extends (A => TraversableOnce[C]) with IrreducibleContainer {
+    second: B => TraversableOnce[C]) extends (A => TraversableOnce[C]) with FunctionContainer {
 
   // Note we don't allocate a new Function in the apply call,
   // we reuse the instances above.
   def apply(a: A) = first(a).flatMap(second)
-  def irreducibles = IrreducibleContainer.flatten(first, second)
+  def innerFunctions = FunctionContainer.flatten(first, second)
 }
 
 /**
  * Composing optionMaps
  */
 case class ComposedOptionMap[A, B, C](first: A => Option[B],
-    second: B => Option[C]) extends (A => Option[C]) with IrreducibleContainer {
+    second: B => Option[C]) extends (A => Option[C]) with FunctionContainer {
 
   // Note we don't allocate a new Function in the apply call,
   // we reuse the instances above.
   def apply(a: A) = first(a).flatMap(second)
-  def irreducibles = IrreducibleContainer.flatten(first, second)
+  def innerFunctions = FunctionContainer.flatten(first, second)
 }
 
 case class ComposedOptionFlat[A, B, C](first: A => Option[B],
-    second: B => TraversableOnce[C]) extends (A => TraversableOnce[C]) with IrreducibleContainer {
+    second: B => TraversableOnce[C]) extends (A => TraversableOnce[C]) with FunctionContainer {
 
   // Note we don't allocate a new Function in the apply call,
   // we reuse the instances above.
   def apply(a: A) = first(a).map(second).getOrElse(Iterator.empty)
-  def irreducibles = IrreducibleContainer.flatten(first, second)
+  def innerFunctions = FunctionContainer.flatten(first, second)
 }
 
 case class OptionToFlat[A, B](optionMap: A => Option[B])
-    extends (A => TraversableOnce[B]) with IrreducibleContainer {
+    extends (A => TraversableOnce[B]) with FunctionContainer {
   // Note we don't allocate a new Function in the apply call,
   // we reuse the instances above.
   def apply(a: A) = optionMap(a).toIterator
-  def irreducibles = IrreducibleContainer.flatten(optionMap)
+  def innerFunctions = FunctionContainer.flatten(optionMap)
 }
 
 /*
@@ -95,18 +69,18 @@ case class OptionToFlat[A, B](optionMap: A => Option[B])
  * This may be useful in Storm where we want to filter before serializing out of
  * the spouts (or other similar fixed-source parition systems)
  */
-case class FlatAsFilter[A](useAsFilter: A => TraversableOnce[Nothing]) extends (A => Option[A]) with IrreducibleContainer {
+case class FlatAsFilter[A](useAsFilter: A => TraversableOnce[Nothing]) extends (A => Option[A]) with FunctionContainer {
   def apply(a: A) = if (useAsFilter(a).isEmpty) None else Some(a)
-  def irreducibles = IrreducibleContainer.flatten(useAsFilter)
+  def innerFunctions = FunctionContainer.flatten(useAsFilter)
 }
 
 /**
  * (a.flatMap(f1) ++ a.flatMap(f2)) == a.flatMap { i => f1(i) ++ f2(i) }
  */
 case class MergeResults[A, B](left: A => TraversableOnce[B], right: A => TraversableOnce[B])
-    extends (A => TraversableOnce[B]) with IrreducibleContainer {
+    extends (A => TraversableOnce[B]) with FunctionContainer {
   // TODO it is not totally clear the fastest way to merge two TraversableOnce instances
   // If they are iterators or iterables, this should be fast
   def apply(a: A) = (left(a).toIterator) ++ (right(a).toIterator)
-  def irreducibles = IrreducibleContainer.flatten(left, right)
+  def innerFunctions = FunctionContainer.flatten(left, right)
 }

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/planner/FunctionContainer.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/planner/FunctionContainer.scala
@@ -1,0 +1,43 @@
+/*
+ Copyright 2015 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.summingbird.planner
+
+/**
+ * This is a marker trait that indicates that
+ * the subclass holds one or more irreducible
+ * items passed by the user. These may need to
+ * be accessed at some planning stage after
+ * optimization in order to attach the correct
+ * options
+ */
+trait FunctionContainer {
+  def innerFunctions: Iterable[Function1[_, _]]
+}
+
+object FunctionContainer {
+  def flatten(item: Function1[_, _]): Iterable[Function1[_, _]] = item match {
+    case (ic: FunctionContainer) => ic.innerFunctions
+    case _ => Seq(item)
+  }
+
+  def flatten(left: Function1[_, _], right: Function1[_, _]): Iterable[Function1[_, _]] = (left, right) match {
+    case (li: FunctionContainer, ri: FunctionContainer) => li.innerFunctions ++ ri.innerFunctions
+    case (li: FunctionContainer, _) => li.innerFunctions ++ Seq(right)
+    case (_, ri: FunctionContainer) => Seq(left) ++ ri.innerFunctions
+    case _ => Seq(left, right)
+  }
+}

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
@@ -18,153 +18,30 @@ package com.twitter.summingbird.planner
 
 import com.twitter.summingbird._
 
-case class ProducerF[P <: Platform[P]](oldSources: List[Producer[P, Any]],
-  oldRef: Producer[P, Any],
-  f: List[Producer[P, Any]] => Producer[P, Any])
-
 object StripNamedNode {
-
-  def castTail[P <: Platform[P]](node: Producer[P, Any]): TailProducer[P, Any] = node.asInstanceOf[TailProducer[P, Any]]
-  def castToPair[P <: Platform[P]](node: Producer[P, Any]): Producer[P, (Any, Any)] = node.asInstanceOf[Producer[P, (Any, Any)]]
-
-  def processLevel[P <: Platform[P]](optLast: Option[Producer[P, Any]],
-    l: TraversableOnce[ProducerF[P]],
-    m: Map[Producer[P, Any], Producer[P, Any]],
-    op: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]]): (Option[Producer[P, Any]], Map[Producer[P, Any], Producer[P, Any]]) = {
-    l.foldLeft((optLast, m)) {
-      case ((nOptLast, nm), pp) =>
-        val ns = pp.oldSources.map(m(_))
-        val res = pp.f(ns)
-        val mutatedRes = if (op.isDefinedAt(res)) {
-          op(res) match {
-            case Some(p) => p
-            case None => ns(0)
-          }
-        } else {
-          res
-        }
-
-        (Some(mutatedRes), (nm + (pp.oldRef -> mutatedRes)))
-    }
-  }
-
-  def functionize[P <: Platform[P]](node: Producer[P, Any]): ProducerF[P] = {
-    node match {
-      // This case is special/different since AlsoTailProducer needs the full class maintained(unlike TailNamedProducer),
-      // but it is not a case class. It inherits from TailProducer so cannot be one.
-      case p: AlsoTailProducer[_, _, _] =>
-        ProducerF(
-          List(p.result.asInstanceOf[Producer[P, Any]], p.ensure.asInstanceOf[Producer[P, Any]]),
-          p,
-          { (newEntries): List[Producer[P, Any]] => new AlsoTailProducer[P, Any, Any](castTail(newEntries(1)), castTail(newEntries(0))) }
-        )
-      case p @ AlsoProducer(_, _) => ProducerF(
-        List(p.result, p.ensure),
-        p,
-        { (newEntries): List[Producer[P, Any]] => p.copy(ensure = castTail(newEntries(1)), result = newEntries(0)) }
-      )
-      case p @ NamedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ Source(_) => ProducerF(
-        List(),
-        p,
-        { producerL: List[Producer[P, Any]] => p }
-      )
-
-      case p @ IdentityKeyedProducer(producer) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ OptionMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ FlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ ValueFlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ KeyFlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ MergedProducer(oL, oR) => ProducerF(
-        List(oL, oR),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(left = producerL(0), right = producerL(1)) }
-      )
-
-      case p @ LeftJoinedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(left = castToPair(producerL(0))) }
-      )
-
-      case p @ Summer(producer, _, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ WrittenProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-    }
-  }
-
-  def toFunctional[P <: Platform[P]](tail: Producer[P, Any]) =
-    graph
-      .dagDepth(Producer.entireGraphOf(tail))(Producer.parentsOf(_))
-      .toSeq
-      .groupBy(_._2)
-      .mapValues(_.map(_._1))
-      .mapValues(_.map(functionize(_)))
-      .toSeq
-
-  def mutateGraph[P <: Platform[P]](tail: Producer[P, Any], op: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]]) = {
-    val newT: Option[Producer[P, Any]] = None
-    val x = toFunctional(tail).sortBy(_._1)
-    x.map(_._2).foldLeft((newT, Map[Producer[P, Any], Producer[P, Any]]())) {
-      case ((optLast, curMap), v) =>
-        processLevel(optLast, v, curMap, op)
-    }
-  }
-
-  def stripNamedNodes[P <: Platform[P]](node: Producer[P, Any]): (Map[Producer[P, Any], Producer[P, Any]], Producer[P, Any]) = {
-    def removeNamed: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]] =
-      { case p @ NamedProducer(p2, _) => None }
-    val (optTail, oldNewMap) = mutateGraph(node, removeNamed)
-    val newTail = optTail.get
-    (oldNewMap.map(x => (x._2, x._1)).toMap, optTail.get)
-  }
-
-  // Priority list of of names for a given producer
-  private def getName[P <: Platform[P]](dependants: Dependants[P], producer: Producer[P, Any]): List[String] = {
-    (producer :: dependants.transitiveDependantsOf(producer)).collect { case NamedProducer(_, n) => n }
-  }
-
   def apply[P <: Platform[P], T](tail: TailProducer[P, T]): (Map[Producer[P, Any], List[String]], TailProducer[P, T]) = {
+    val opt = new DagOptimizer[P] {}
+    val newTail = opt.optimize(tail, opt.RemoveNames).asInstanceOf[TailProducer[P, T]]
     val dependants = Dependants(tail)
-    val (oldProducerToNewMap, newTail) = stripNamedNodes(tail)
-    (oldProducerToNewMap.mapValues(n => getName(dependants, n)), newTail.asInstanceOf[TailProducer[P, T]])
+    // Where is each irreducible in the original graph:
+    val irrMap: Map[Irreducible[P], List[Producer[P, Any]]] = (for {
+      prod <- dependants.nodes
+      irr <- Producer.irreduciblesOf(prod)
+    } yield irr -> prod)
+      .groupBy(_._1)
+      .map { case (irr, it) => irr -> it.map(_._2).toList }
+
+    def originalName(p: Producer[P, Any]): List[String] =
+      dependants.namesOf(p).map(_.id)
+
+    def newToOld(p: Producer[P, Any]): List[Producer[P, Any]] =
+      Producer.irreduciblesOf(p).flatMap(irrMap)
+
+    def newName(p: Producer[P, Any]): List[String] =
+      newToOld(p).flatMap(originalName)
+
+    val newDependants = Dependants(newTail)
+
+    (newDependants.nodes.map { n => n -> newName(n) }.toMap, newTail)
   }
 }


### PR DESCRIPTION
This is part of #542 to use the DagOptimizer code more.

This addresses a main issue: the names were ill-defined after optimization before. This code changes the naming to apply to the irreducible things in the graph: functions, stores, services, sources, semigroups, sinks. So, even after optimization the names can be recovered.

Tests pass, and I think we have good tests on names, so I think we should move forward.