### PR TITLE
Reenable tests

### DIFF
--- a/summingbird-batch/src/test/scala/com/twitter/summingbird/batch/BatchLaws.scala
+++ b/summingbird-batch/src/test/scala/com/twitter/summingbird/batch/BatchLaws.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.summingbird.batch
 
-import org.scalacheck.{ Arbitrary, Properties }
+import org.scalacheck.{ Arbitrary, Gen, Properties }
 import org.scalacheck.Prop._
 
 import java.util.concurrent.TimeUnit
@@ -51,9 +51,9 @@ object BatchLaws extends Properties("BatchID") {
     }
 
   property("range, toInterval and toIterable should be equivalent") =
-    forAll { (b1: BatchID, diff: Short) =>
+    forAll(Arbitrary.arbitrary[BatchID], Gen.choose(0L, 1000L)) { (b1: BatchID, diff: Long) =>
       // We can't enumerate too much:
-      val b2 = b1 + math.abs(diff.toLong)
+      val b2 = b1 + diff
       val interval = Interval.leftClosedRightOpen(b1, b2.next) match {
         case Left(i) => i
         case Right(i) => i

--- a/summingbird-batch/src/test/scala/com/twitter/summingbird/batch/BatchLaws.scala
+++ b/summingbird-batch/src/test/scala/com/twitter/summingbird/batch/BatchLaws.scala
@@ -50,15 +50,15 @@ object BatchLaws extends Properties("BatchID") {
         BatchID(b).prev == BatchID(b - 1L)
     }
 
-  //todo: fix me: This test just hangs
-/*  property("range, toInterval and toIterable should be equivalent") =
-    forAll { (b1: BatchID, diff: SmallLong) =>
-      val b2 = b1 + (diff.get)
+  property("range, toInterval and toIterable should be equivalent") =
+    forAll { (b1: BatchID, diff: Short) =>
+      // We can't enumerate too much:
+      val b2 = b1 + math.abs(diff.toLong)
       val interval = Interval.leftClosedRightOpen(b1, b2.next) match {
         case Left(i) => i
         case Right(i) => i
       }
       (BatchID.toInterval(BatchID.range(b1, b2)) == Some(interval)) &&
         BatchID.toIterable(interval).toList == BatchID.range(b1, b2).toList
-    }*/
+    }
 }

--- a/summingbird-scalding-test/src/test/scala/com/twitter/summingbird/scalding/VersionBatchLaws.scala
+++ b/summingbird-scalding-test/src/test/scala/com/twitter/summingbird/scalding/VersionBatchLaws.scala
@@ -49,13 +49,15 @@ import org.apache.hadoop.mapred.OutputCollector
 import org.specs2.mutable._
 
 object VersionBatchLaws extends Properties("VersionBatchLaws") {
-  //todo: fix me. this test is failing
-/*  property("version -> BatchID -> version") = forAll { (l: Long) =>
-    val vbs = new store.VersionedBatchStore[Int, Int, Array[Byte], Array[Byte]](null,
-      0, Batcher.ofHours(1))(null)(null)
-    val b = vbs.versionToBatchID(l)
-    vbs.batchIDToVersion(b) <= l
-  }*/
+  property("version -> BatchID -> version") = forAll { (l: Long) =>
+    (l == Long.MinValue) || {
+      // This law is only true for numbers greater than MinValue
+      val vbs = new store.VersionedBatchStore[Int, Int, Array[Byte], Array[Byte]](null,
+        0, Batcher.ofHours(1))(null)(null)
+      val b = vbs.versionToBatchID(l)
+      vbs.batchIDToVersion(b) <= l
+    }
+  }
   property("BatchID -> version -> BatchID") = forAll { (bint: Int) =>
     val b = BatchID(bint)
     val vbs = new store.VersionedBatchStore[Int, Int, Array[Byte], Array[Byte]](null,


### PR DESCRIPTION
These were just failing in #599 because we updated scalacheck and it was using boundaries more, and the laws were too strict.

No real breakage.