### PR TITLE
Spout storm metrics foreach

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -197,7 +197,7 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
     val registerAllMetrics = new Function1[TopologyContext, Unit] {
       def apply(context: TopologyContext) = {
         // Register metrics passed in SpoutStormMetrics option.
-        metrics.metrics().map {
+        metrics.metrics().foreach {
           x: StormMetric[IMetric] =>
             context.registerMetric(x.name, x.metric, x.interval.inSeconds)
         }


### PR DESCRIPTION
This was a bug where the metrics that are passed as NamedOptions weren't registered because .map on a TraversableOnce is lazy. This fixes the issue with a .foreach instead. 