### PR TITLE
Add a test for naming, and name stripping

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
@@ -35,6 +35,9 @@ object Options {
       innerOpts <- options.get(id)
       option <- innerOpts.get[T]
     } yield (id, option)).headOption
+
+  def get[T <: AnyRef: ClassTag](options: Map[String, Options], name: String): Option[T] =
+    options.get(name).flatMap(_.get[T])
 }
 class Options(val opts: Map[Class[_], Any]) {
   def set(opt: Any) = Options(opts + (opt.getClass -> opt))

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
@@ -26,6 +26,15 @@ import scala.reflect.{ classTag, ClassTag }
 
 object Options {
   def apply(opts: Map[Class[_], Any] = Map.empty): Options = new Options(opts)
+  /**
+   * Given a list of names, return the first option, if it exists, from the given options
+   */
+  def getFirst[T <: AnyRef: ClassTag](options: Map[String, Options], names: List[String]): Option[(String, T)] =
+    (for {
+      id <- names :+ "DEFAULT"
+      innerOpts <- options.get(id)
+      option <- innerOpts.get[T]
+    } yield (id, option)).headOption
 }
 class Options(val opts: Map[Class[_], Any]) {
   def set(opt: Any) = Options(opts + (opt.getClass -> opt))

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Options.scala
@@ -27,15 +27,18 @@ import scala.reflect.{ classTag, ClassTag }
 object Options {
   def apply(opts: Map[Class[_], Any] = Map.empty): Options = new Options(opts)
   /**
-   * Given a list of names, return the first option, if it exists, from the given options
+   * Given a list of names, return the first option and the name that matches,
+   * if it exists, from the given options
    */
   def getFirst[T <: AnyRef: ClassTag](options: Map[String, Options], names: List[String]): Option[(String, T)] =
     (for {
       id <- names :+ "DEFAULT"
-      innerOpts <- options.get(id)
-      option <- innerOpts.get[T]
+      option <- get[T](options, id)
     } yield (id, option)).headOption
 
+  /**
+   * Get the option of type T for the given name
+   */
   def get[T <: AnyRef: ClassTag](options: Map[String, Options], name: String): Option[T] =
     options.get(name).flatMap(_.get[T])
 }

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
@@ -1,0 +1,104 @@
+package com.twitter.summingbird.online
+
+import com.twitter.summingbird.memory.Memory
+import com.twitter.summingbird.planner.StripNamedNode
+import com.twitter.summingbird.{ Dependants, Producer, OptionMappedProducer, NamedProducer, Source, Summer }
+import org.scalatest.FunSuite
+import scala.collection.mutable.{ Map => MMap }
+
+class StripNameTest extends FunSuite {
+
+  test("simple name test") {
+    /*
+     * Here are the irreducible items
+     */
+    val store = MMap[Int, Int]()
+    val input = List(1, 2, 4)
+    val fn = { k: Int => Some((k % 2, k * k)) }
+
+    val src = Producer.source[Memory, Int](input)
+    val mapped = src
+      .name("source")
+      .optionMap(fn)
+    val summed = mapped
+      .name("map")
+      .sumByKey(store)
+    val graph = summed
+      .name("sumByKey")
+
+    val deps = Dependants(graph)
+    assert(deps.namesOf(src).map(_.id).toSet == Set("source", "map", "sumByKey"))
+    assert(deps.namesOf(mapped).map(_.id).toSet == Set("map", "sumByKey"))
+    assert(deps.namesOf(summed).map(_.id).toSet == Set("sumByKey"))
+
+    val (nameMap, stripped) = StripNamedNode(graph)
+    val strippedDeps = Dependants(stripped)
+
+    def assertName(names: Set[String])(p: PartialFunction[Producer[Memory, Any], Producer[Memory, Any]]): Unit = {
+      val nodes = strippedDeps.nodes.collect(p)
+      assert(nodes.size == 1) // Only one node
+      assert(nameMap(nodes(0)).toSet == names, s"checking ${names}")
+    }
+
+    assertName(Set("source", "map", "sumByKey")) { case p @ Source(l) if l == input => p }
+    assertName(Set("map", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn => p }
+    assertName(Set("sumByKey")) { case p @ Summer(_, str, _) if str == store => p }
+
+    // The final stripped has no names:
+    assert(strippedDeps.nodes.collect { case NamedProducer(_, _) => 1 }.sum == 0)
+  }
+  test("merge name test") {
+    /*
+     * Here are the irreducible items
+     */
+    val store = MMap[Int, Int]()
+    val input0 = List(1, 2, 4)
+    val input1 = List("100", "200", "400")
+    val fn0 = { k: Int => Some((k % 2, k * k)) }
+    val fn1 = { kstr: String => val k = kstr.toInt; Some((k % 2, k * k)) }
+
+    val src0 = Producer.source[Memory, Int](input0)
+    val mapped0 = src0
+      .name("source0")
+      .optionMap(fn0)
+    val named0 = mapped0.name("map0")
+
+    val src1 = Producer.source[Memory, String](input1)
+    val mapped1 = src1
+      .name("source1")
+      .optionMap(fn1)
+    val named1 = mapped1.name("map1")
+
+    val summed = (named0 ++ named1).sumByKey(store)
+    val graph = summed
+      .name("sumByKey")
+
+    val deps = Dependants(graph)
+    def assertInitName(n: Producer[Memory, Any], s: Set[String]) =
+      assert(deps.namesOf(n).map(_.id).toSet == s)
+
+    assertInitName(src0, Set("source0", "map0", "sumByKey"))
+    assertInitName(src1, Set("source1", "map1", "sumByKey"))
+    assertInitName(mapped0, Set("map0", "sumByKey"))
+    assertInitName(mapped1, Set("map1", "sumByKey"))
+    assertInitName(summed, Set("sumByKey"))
+
+    val (nameMap, stripped) = StripNamedNode(graph)
+    val strippedDeps = Dependants(stripped)
+
+    def assertName(names: Set[String])(p: PartialFunction[Producer[Memory, Any], Producer[Memory, Any]]): Unit = {
+      val nodes = strippedDeps.nodes.collect(p)
+      assert(nodes.size == 1) // Only one node
+      assert(nameMap(nodes(0)).toSet == names, s"checking ${names}")
+    }
+
+    assertName(Set("source0", "map0", "sumByKey")) { case p @ Source(l) if l == input0 => p }
+    assertName(Set("map0", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn0 => p }
+    assertName(Set("source1", "map1", "sumByKey")) { case p @ Source(l) if l == input1 => p }
+    assertName(Set("map1", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn1 => p }
+    assertName(Set("sumByKey")) { case p @ Summer(_, str, _) if str == store => p }
+
+    // The final stripped has no names:
+    assert(strippedDeps.nodes.collect { case NamedProducer(_, _) => 1 }.sum == 0)
+  }
+}

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
@@ -74,29 +74,29 @@ class StripNameTest extends FunSuite {
       .name("sumByKey")
 
     val deps = Dependants(graph)
-    def assertInitName(n: Producer[Memory, Any], s: Set[String]) =
-      assert(deps.namesOf(n).map(_.id).toSet == s)
+    def assertInitName(n: Producer[Memory, Any], s: List[String]) =
+      assert(deps.namesOf(n).map(_.id) == s)
 
-    assertInitName(src0, Set("source0", "map0", "sumByKey"))
-    assertInitName(src1, Set("source1", "map1", "sumByKey"))
-    assertInitName(mapped0, Set("map0", "sumByKey"))
-    assertInitName(mapped1, Set("map1", "sumByKey"))
-    assertInitName(summed, Set("sumByKey"))
+    assertInitName(src0, List("source0", "map0", "sumByKey"))
+    assertInitName(src1, List("source1", "map1", "sumByKey"))
+    assertInitName(mapped0, List("map0", "sumByKey"))
+    assertInitName(mapped1, List("map1", "sumByKey"))
+    assertInitName(summed, List("sumByKey"))
 
     val (nameMap, stripped) = StripNamedNode(graph)
     val strippedDeps = Dependants(stripped)
 
-    def assertName(names: Set[String])(p: PartialFunction[Producer[Memory, Any], Producer[Memory, Any]]): Unit = {
+    def assertName(names: List[String])(p: PartialFunction[Producer[Memory, Any], Producer[Memory, Any]]): Unit = {
       val nodes = strippedDeps.nodes.collect(p)
       assert(nodes.size == 1) // Only one node
-      assert(nameMap(nodes(0)).toSet == names, s"checking ${names}")
+      assert(nameMap(nodes(0)) == names, s"checking ${names}")
     }
 
-    assertName(Set("source0", "map0", "sumByKey")) { case p @ Source(l) if l == input0 => p }
-    assertName(Set("map0", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn0 => p }
-    assertName(Set("source1", "map1", "sumByKey")) { case p @ Source(l) if l == input1 => p }
-    assertName(Set("map1", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn1 => p }
-    assertName(Set("sumByKey")) { case p @ Summer(_, str, _) if str == store => p }
+    assertName(List("source0", "map0", "sumByKey")) { case p @ Source(l) if l == input0 => p }
+    assertName(List("map0", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn0 => p }
+    assertName(List("source1", "map1", "sumByKey")) { case p @ Source(l) if l == input1 => p }
+    assertName(List("map1", "sumByKey")) { case p @ OptionMappedProducer(_, f) if f == fn1 => p }
+    assertName(List("sumByKey")) { case p @ Summer(_, str, _) if str == store => p }
 
     // The final stripped has no names:
     assert(strippedDeps.nodes.collect { case NamedProducer(_, _) => 1 }.sum == 0)

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
@@ -86,8 +86,7 @@ object Scalding {
   def emptyFlowProducer[T]: FlowProducer[TypedPipe[T]] =
     Reader({ implicit fdm: (FlowDef, Mode) => TypedPipe.empty })
 
-  def getCommutativity(
-    names: List[String],
+  def getCommutativity(names: List[String],
     options: Map[String, Options],
     s: Summer[Scalding, _, _]): Commutativity = {
 
@@ -273,20 +272,17 @@ object Scalding {
     }
   }
 
-  private def getOrElse[T <: AnyRef: ClassTag](
-    options: Map[String, Options],
+  private def getOrElse[T <: AnyRef: ClassTag](options: Map[String, Options],
     names: List[String],
     producer: Producer[Scalding, _], default: => T): T =
     Options.getFirst[T](options, names) match {
       case None =>
         logger.debug(
-          s"Producer (${producer.getClass.getName}): Using default setting $default"
-        )
+          s"Producer (${producer.getClass.getName}): Using default setting $default")
         default
       case Some((id, opt)) =>
         logger.info(
-          s"Producer (${producer.getClass.getName}) Using $opt found via NamedProducer ${'"'}$id${'"'}"
-        )
+          s"Producer (${producer.getClass.getName}) Using $opt found via NamedProducer ${'"'}$id${'"'}")
         opt
     }
 
@@ -294,8 +290,7 @@ object Scalding {
    * Return a PipeFactory that can cover as much as possible of the time range requested,
    * but the output state gives the actual, non-empty, interval that can be produced
    */
-  private def buildFlow[T](
-    options: Map[String, Options],
+  private def buildFlow[T](options: Map[String, Options],
     producer: Producer[Scalding, T],
     fanOuts: Set[Producer[Scalding, _]],
     dependants: Dependants[Scalding],
@@ -304,8 +299,7 @@ object Scalding {
 
     val names = dependants.namesOf(producer).map(_.id)
 
-    def recurse[U](
-      p: Producer[Scalding, U],
+    def recurse[U](p: Producer[Scalding, U],
       built: Map[Producer[Scalding, _], PipeFactory[_]] = built,
       forceFanOut: Boolean = forceFanOut): (PipeFactory[U], Map[Producer[Scalding, _], PipeFactory[_]]) = {
       buildFlow(options, p, fanOuts, dependants, built, forceFanOut)
@@ -385,8 +379,7 @@ object Scalding {
               implicit val keyOrdering = bstore.ordering
               val Summer(storeLog, _, sg) = InternalService.getSummer[K, V](dependants, bstore)
                 .getOrElse(
-                  sys.error("join %s is against store not in the entire job's Dag".format(ljp))
-                )
+                  sys.error("join %s is against store not in the entire job's Dag".format(ljp)))
               val (leftPf, m1) = recurse(left)
               // We have to force the fanOut on the storeLog because this kind of fanout
               // due to joining is not visible in the Dependants dag
@@ -420,8 +413,7 @@ object Scalding {
               implicit val keyOrdering = bs.ordering
               val Summer(storeLog, _, sg) = InternalService.getSummer[K, U](dependants, bs)
                 .getOrElse(
-                  sys.error("join %s is against store not in the entire job's Dag".format(ljp))
-                )
+                  sys.error("join %s is against store not in the entire job's Dag".format(ljp)))
               implicit val semigroup: Semigroup[U] = sg
               logger.info("Service {} using {} reducers (-1 means unset)", ljp, reducers)
 
@@ -573,8 +565,7 @@ object Scalding {
    * Note this may return a smaller DateRange than you ask for
    * If you need an exact DateRange see toPipeExact.
    */
-  def toPipe[T](
-    dr: DateRange,
+  def toPipe[T](dr: DateRange,
     prod: Producer[Scalding, T],
     opts: Map[String, Options] = Map.empty)(implicit fd: FlowDef, mode: Mode): Try[(DateRange, TypedPipe[(Timestamp, T)])] = {
     val ts = dr.as[Interval[Timestamp]]
@@ -589,8 +580,7 @@ object Scalding {
    * Use this method to interop with existing scalding code that expects
    * to schedule an exact DateRange or fail.
    */
-  def toPipeExact[T](
-    dr: DateRange,
+  def toPipeExact[T](dr: DateRange,
     prod: Producer[Scalding, T],
     opts: Map[String, Options] = Map.empty)(implicit fd: FlowDef, mode: Mode): Try[TypedPipe[(Timestamp, T)]] = {
     val ts = dr.as[Interval[Timestamp]]
@@ -598,8 +588,7 @@ object Scalding {
     toPipeExact(ts, fd, mode, pf)
   }
 
-  def toPipe[T](
-    timeSpan: Interval[Timestamp],
+  def toPipe[T](timeSpan: Interval[Timestamp],
     flowDef: FlowDef,
     mode: Mode,
     pf: PipeFactory[T]): Try[(Interval[Timestamp], TimedPipe[T])] = {
@@ -609,8 +598,7 @@ object Scalding {
       .map { case (((ts, m), flowDefMutator)) => (ts, flowDefMutator((flowDef, m))) }
   }
 
-  def toPipeExact[T](
-    timeSpan: Interval[Timestamp],
+  def toPipeExact[T](timeSpan: Interval[Timestamp],
     flowDef: FlowDef,
     mode: Mode,
     pf: PipeFactory[T]): Try[TimedPipe[T]] = {
@@ -685,8 +673,7 @@ class Scalding(
 
       conf
         .setSerialization(
-          Left((classOf[serialization.KryoHadoop], initKryo.withRegistrar(kryoReg))), Nil
-        )
+          Left((classOf[serialization.KryoHadoop], initKryo.withRegistrar(kryoReg))), Nil)
     }
   }
 
@@ -723,19 +710,16 @@ class Scalding(
       }
   }
 
-  def run(
-    state: WaitingState[Interval[Timestamp]],
+  def run(state: WaitingState[Interval[Timestamp]],
     mode: Mode,
     pf: TailProducer[Scalding, Any]): WaitingState[Interval[Timestamp]] =
     run(state, mode, plan(pf))
 
-  def run(
-    state: WaitingState[Interval[Timestamp]],
+  def run(state: WaitingState[Interval[Timestamp]],
     mode: Mode,
     pf: PipeFactory[Any]): WaitingState[Interval[Timestamp]] = run(state, mode, pf, (f: Flow[_]) => Unit)
 
-  def run(
-    state: WaitingState[Interval[Timestamp]],
+  def run(state: WaitingState[Interval[Timestamp]],
     mode: Mode,
     pf: PipeFactory[Any],
     mutate: Flow[_] => Unit): WaitingState[Interval[Timestamp]] = {

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
@@ -89,8 +89,7 @@ object Scalding {
   def getCommutativity(
     names: List[String],
     options: Map[String, Options],
-    s: Summer[Scalding, _, _]
-  ): Commutativity = {
+    s: Summer[Scalding, _, _]): Commutativity = {
 
     val commutativity = getOrElse(options, names, s, {
       val default = MonoidIsCommutative.default
@@ -226,8 +225,7 @@ object Scalding {
     }
 
   def sourceFromMappable[T: TimeExtractor: Manifest](
-    factory: (DateRange) => Mappable[T]
-  ): Producer[Scalding, T] =
+    factory: (DateRange) => Mappable[T]): Producer[Scalding, T] =
     Producer.source[Scalding, T](pipeFactory(factory))
 
   def toDateRange(timeSpan: Interval[Timestamp]): Try[DateRange] =
@@ -278,8 +276,7 @@ object Scalding {
   private def getOrElse[T <: AnyRef: ClassTag](
     options: Map[String, Options],
     names: List[String],
-    producer: Producer[Scalding, _], default: => T
-  ): T =
+    producer: Producer[Scalding, _], default: => T): T =
     Options.getFirst[T](options, names) match {
       case None =>
         logger.debug(
@@ -303,16 +300,14 @@ object Scalding {
     fanOuts: Set[Producer[Scalding, _]],
     dependants: Dependants[Scalding],
     built: Map[Producer[Scalding, _], PipeFactory[_]],
-    forceFanOut: Boolean = false
-  ): (PipeFactory[T], Map[Producer[Scalding, _], PipeFactory[_]]) = {
+    forceFanOut: Boolean = false): (PipeFactory[T], Map[Producer[Scalding, _], PipeFactory[_]]) = {
 
     val names = dependants.namesOf(producer).map(_.id)
 
     def recurse[U](
       p: Producer[Scalding, U],
       built: Map[Producer[Scalding, _], PipeFactory[_]] = built,
-      forceFanOut: Boolean = forceFanOut
-    ): (PipeFactory[U], Map[Producer[Scalding, _], PipeFactory[_]]) = {
+      forceFanOut: Boolean = forceFanOut): (PipeFactory[U], Map[Producer[Scalding, _], PipeFactory[_]]) = {
       buildFlow(options, p, fanOuts, dependants, built, forceFanOut)
     }
 
@@ -581,8 +576,7 @@ object Scalding {
   def toPipe[T](
     dr: DateRange,
     prod: Producer[Scalding, T],
-    opts: Map[String, Options] = Map.empty
-  )(implicit fd: FlowDef, mode: Mode): Try[(DateRange, TypedPipe[(Timestamp, T)])] = {
+    opts: Map[String, Options] = Map.empty)(implicit fd: FlowDef, mode: Mode): Try[(DateRange, TypedPipe[(Timestamp, T)])] = {
     val ts = dr.as[Interval[Timestamp]]
     val pf = planProducer(opts, prod)
     toPipe(ts, fd, mode, pf).right.map {
@@ -598,8 +592,7 @@ object Scalding {
   def toPipeExact[T](
     dr: DateRange,
     prod: Producer[Scalding, T],
-    opts: Map[String, Options] = Map.empty
-  )(implicit fd: FlowDef, mode: Mode): Try[TypedPipe[(Timestamp, T)]] = {
+    opts: Map[String, Options] = Map.empty)(implicit fd: FlowDef, mode: Mode): Try[TypedPipe[(Timestamp, T)]] = {
     val ts = dr.as[Interval[Timestamp]]
     val pf = planProducer(opts, prod)
     toPipeExact(ts, fd, mode, pf)
@@ -609,8 +602,7 @@ object Scalding {
     timeSpan: Interval[Timestamp],
     flowDef: FlowDef,
     mode: Mode,
-    pf: PipeFactory[T]
-  ): Try[(Interval[Timestamp], TimedPipe[T])] = {
+    pf: PipeFactory[T]): Try[(Interval[Timestamp], TimedPipe[T])] = {
     logger.info("topipe Planning on interval: {}", timeSpan)
     pf((timeSpan, mode))
       .right
@@ -621,8 +613,7 @@ object Scalding {
     timeSpan: Interval[Timestamp],
     flowDef: FlowDef,
     mode: Mode,
-    pf: PipeFactory[T]
-  ): Try[TimedPipe[T]] = {
+    pf: PipeFactory[T]): Try[TimedPipe[T]] = {
     logger.info("Planning on interval: {}", timeSpan.as[Option[DateRange]])
     pf((timeSpan, mode))
       .right
@@ -659,8 +650,7 @@ class Scalding(
   val jobName: String,
   @transient val options: Map[String, Options],
   @transient transformConfig: Config => Config,
-  @transient passedRegistrars: List[IKryoRegistrar]
-)
+  @transient passedRegistrars: List[IKryoRegistrar])
     extends Platform[Scalding] with java.io.Serializable {
 
   type Source[T] = PipeFactory[T]
@@ -736,22 +726,19 @@ class Scalding(
   def run(
     state: WaitingState[Interval[Timestamp]],
     mode: Mode,
-    pf: TailProducer[Scalding, Any]
-  ): WaitingState[Interval[Timestamp]] =
+    pf: TailProducer[Scalding, Any]): WaitingState[Interval[Timestamp]] =
     run(state, mode, plan(pf))
 
   def run(
     state: WaitingState[Interval[Timestamp]],
     mode: Mode,
-    pf: PipeFactory[Any]
-  ): WaitingState[Interval[Timestamp]] = run(state, mode, pf, (f: Flow[_]) => Unit)
+    pf: PipeFactory[Any]): WaitingState[Interval[Timestamp]] = run(state, mode, pf, (f: Flow[_]) => Unit)
 
   def run(
     state: WaitingState[Interval[Timestamp]],
     mode: Mode,
     pf: PipeFactory[Any],
-    mutate: Flow[_] => Unit
-  ): WaitingState[Interval[Timestamp]] = {
+    mutate: Flow[_] => Unit): WaitingState[Interval[Timestamp]] = {
 
     val config = mode match {
       case Hdfs(_, conf) =>

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -101,8 +101,7 @@ object Storm {
 
   def toStormSource[T](
     spout: Spout[T],
-    defaultSourcePar: Option[Int] = None
-  )(implicit timeOf: TimeExtractor[T]): StormSource[T] =
+    defaultSourcePar: Option[Int] = None)(implicit timeOf: TimeExtractor[T]): StormSource[T] =
     SpoutSource(spout.map(t => (Timestamp(timeOf(t)), t)), defaultSourcePar.map(SourceParallelism(_)))
 
   implicit def spoutAsStormSource[T](spout: Spout[T])(implicit timeOf: TimeExtractor[T]): StormSource[T] =
@@ -110,8 +109,7 @@ object Storm {
 
   def source[T](
     spout: Spout[T],
-    defaultSourcePar: Option[Int] = None
-  )(implicit timeOf: TimeExtractor[T]): Producer[Storm, T] =
+    defaultSourcePar: Option[Int] = None)(implicit timeOf: TimeExtractor[T]): Producer[Storm, T] =
     Producer.source[Storm, T](toStormSource(spout, defaultSourcePar))
 
   implicit def spoutAsSource[T](spout: Spout[T])(implicit timeOf: TimeExtractor[T]): Producer[Storm, T] =


### PR DESCRIPTION
This is to address #633. It is not closing that issue, but it is a start.

Also, this exposes something that I think is a problem: the naming strategy seems pretty broken to me. I think names/options are pretty ill-specified. For instance, looking up options is done in the platforms. Scalding takes the first name that matches:

https://github.com/twitter/summingbird/blob/develop/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala#L274

which, does not really make sense if two names match due to a fan-out situation.

The solution I would propose is this:

0) move the option resolving code to a common location and don't repeat that code on the platforms.
1) we only return the first name node we can reach on each branch. So, you can only have more than one name if there is a fan-out and you are named on each branch.
2) Each option has a rule for how to combine if a node has more than one name (fanout) and each of those names has an option set.
3) default only comes into play if there is no name set.