### PR TITLE
re-enable Dag Optimizer to strip names

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
@@ -25,7 +25,7 @@ case class ProducerF[P <: Platform[P]](oldSources: List[Producer[P, Any]],
 
 object StripNamedNode {
 
-  private def castTail[P <: Platform[P], T](node: Producer[P, T]): TailProducer[P, T] =
+  private[this] def castTail[P <: Platform[P], T](node: Producer[P, T]): TailProducer[P, T] =
     node.asInstanceOf[TailProducer[P, T]]
 
   /**
@@ -42,7 +42,12 @@ object StripNamedNode {
       case LeftJoinedProducer(_, serv) => Some(serv)
       case Summer(_, store, semi) => Some((store, semi))
       case WrittenProducer(_, sink) => Some(sink)
-      case _ => None
+      // The following have nothing to put options on:
+      case AlsoProducer(_, producer) => None
+      case NamedProducer(producer, _) => None
+      case IdentityKeyedProducer(producer) => None
+      case MergedProducer(l, r) => None
+      case _ => sys.error("Unreachable. Here to warn us if we add Producer subclasses but forget to update this")
     }
 
   def apply[P <: Platform[P], T](tail: TailProducer[P, T]): (Map[Producer[P, Any], List[String]], TailProducer[P, T]) = {

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/StripNamedNodes.scala
@@ -17,6 +17,7 @@
 package com.twitter.summingbird.planner
 
 import com.twitter.summingbird._
+import scala.collection.breakOut
 
 case class ProducerF[P <: Platform[P]](oldSources: List[Producer[P, Any]],
   oldRef: Producer[P, Any],
@@ -24,147 +25,67 @@ case class ProducerF[P <: Platform[P]](oldSources: List[Producer[P, Any]],
 
 object StripNamedNode {
 
-  def castTail[P <: Platform[P]](node: Producer[P, Any]): TailProducer[P, Any] = node.asInstanceOf[TailProducer[P, Any]]
-  def castToPair[P <: Platform[P]](node: Producer[P, Any]): Producer[P, (Any, Any)] = node.asInstanceOf[Producer[P, (Any, Any)]]
+  private def castTail[P <: Platform[P], T](node: Producer[P, T]): TailProducer[P, T] =
+    node.asInstanceOf[TailProducer[P, T]]
 
-  def processLevel[P <: Platform[P]](optLast: Option[Producer[P, Any]],
-    l: TraversableOnce[ProducerF[P]],
-    m: Map[Producer[P, Any], Producer[P, Any]],
-    op: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]]): (Option[Producer[P, Any]], Map[Producer[P, Any], Producer[P, Any]]) = {
-    l.foldLeft((optLast, m)) {
-      case ((nOptLast, nm), pp) =>
-        val ns = pp.oldSources.map(m(_))
-        val res = pp.f(ns)
-        val mutatedRes = if (op.isDefinedAt(res)) {
-          op(res) match {
-            case Some(p) => p
-            case None => ns(0)
-          }
-        } else {
-          res
-        }
-
-        (Some(mutatedRes), (nm + (pp.oldRef -> mutatedRes)))
-    }
-  }
-
-  def functionize[P <: Platform[P]](node: Producer[P, Any]): ProducerF[P] = {
+  /**
+   * Names apply to the sources, sinks, services, stores, semigroups and functions that the user passes in
+   * This returns those
+   */
+  private def irreducible[P <: Platform[P]](node: Producer[P, Any]): Option[Any] =
     node match {
-      // This case is special/different since AlsoTailProducer needs the full class maintained(unlike TailNamedProducer),
-      // but it is not a case class. It inherits from TailProducer so cannot be one.
-      case p: AlsoTailProducer[_, _, _] =>
-        ProducerF(
-          List(p.result.asInstanceOf[Producer[P, Any]], p.ensure.asInstanceOf[Producer[P, Any]]),
-          p,
-          { (newEntries): List[Producer[P, Any]] => new AlsoTailProducer[P, Any, Any](castTail(newEntries(1)), castTail(newEntries(0))) }
-        )
-      case p @ AlsoProducer(_, _) => ProducerF(
-        List(p.result, p.ensure),
-        p,
-        { (newEntries): List[Producer[P, Any]] => p.copy(ensure = castTail(newEntries(1)), result = newEntries(0)) }
-      )
-      case p @ NamedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ Source(_) => ProducerF(
-        List(),
-        p,
-        { producerL: List[Producer[P, Any]] => p }
-      )
-
-      case p @ IdentityKeyedProducer(producer) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ OptionMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ FlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
-
-      case p @ ValueFlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ KeyFlatMappedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ MergedProducer(oL, oR) => ProducerF(
-        List(oL, oR),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(left = producerL(0), right = producerL(1)) }
-      )
-
-      case p @ LeftJoinedProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(left = castToPair(producerL(0))) }
-      )
-
-      case p @ Summer(producer, _, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = castToPair(producerL(0))) }
-      )
-
-      case p @ WrittenProducer(producer, _) => ProducerF(
-        List(producer),
-        p,
-        { producerL: List[Producer[P, Any]] => p.copy(producer = producerL(0)) }
-      )
+      case Source(src) => Some(src)
+      case OptionMappedProducer(_, fn) => Some(fn)
+      case FlatMappedProducer(_, fn) => Some(fn)
+      case ValueFlatMappedProducer(_, fn) => Some(fn)
+      case KeyFlatMappedProducer(_, fn) => Some(fn)
+      case LeftJoinedProducer(_, serv) => Some(serv)
+      case Summer(_, store, semi) => Some((store, semi))
+      case WrittenProducer(_, sink) => Some(sink)
+      case _ => None
     }
-  }
-
-  def toFunctional[P <: Platform[P]](tail: Producer[P, Any]) =
-    graph
-      .dagDepth(Producer.entireGraphOf(tail))(Producer.parentsOf(_))
-      .toSeq
-      .groupBy(_._2)
-      .mapValues(_.map(_._1))
-      .mapValues(_.map(functionize(_)))
-      .toSeq
-
-  def mutateGraph[P <: Platform[P]](tail: Producer[P, Any], op: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]]) = {
-    val newT: Option[Producer[P, Any]] = None
-    val x = toFunctional(tail).sortBy(_._1)
-    x.map(_._2).foldLeft((newT, Map[Producer[P, Any], Producer[P, Any]]())) {
-      case ((optLast, curMap), v) =>
-        processLevel(optLast, v, curMap, op)
-    }
-  }
-
-  def stripNamedNodes[P <: Platform[P]](node: Producer[P, Any]): (Map[Producer[P, Any], Producer[P, Any]], Producer[P, Any]) = {
-    def removeNamed: PartialFunction[Producer[P, Any], Option[Producer[P, Any]]] =
-      { case p @ NamedProducer(p2, _) => None }
-    val (optTail, oldNewMap) = mutateGraph(node, removeNamed)
-    val newTail = optTail.get
-    (oldNewMap.map(x => (x._2, x._1)).toMap, optTail.get)
-  }
-
-  // Priority list of of names for a given producer
-  private def getName[P <: Platform[P]](dependants: Dependants[P], producer: Producer[P, Any]): List[String] = {
-    (producer :: dependants.transitiveDependantsOf(producer)).collect { case NamedProducer(_, n) => n }
-  }
 
   def apply[P <: Platform[P], T](tail: TailProducer[P, T]): (Map[Producer[P, Any], List[String]], TailProducer[P, T]) = {
+    val dagOpt = new DagOptimizer[P] {}
+    // It must be a tail, but the optimizer doesn't retain that information
+    val newTail = castTail(dagOpt.optimize(tail, dagOpt.RemoveNames))
+    /**
+     * Two nodes are the same if the irreducibles of their transitive dependencies are the same.
+     * We use a Map here because the traversals can be ordered slightly differently
+     */
+    def transIrr(p: Producer[P, Any]): Map[Any, Int] =
+      (p :: Producer.transitiveDependenciesOf(p))
+        .map(irreducible)
+        .collect { case Some(irr) => irr }
+        .groupBy(identity)
+        .mapValues(_.size)
+
     val dependants = Dependants(tail)
-    val (oldProducerToNewMap, newTail) = stripNamedNodes(tail)
-    (oldProducerToNewMap.mapValues(n => getName(dependants, n)), newTail.asInstanceOf[TailProducer[P, T]])
+    val newDependants = Dependants(newTail)
+
+    /**
+     * Each bag of irreducibles can point to more than one node because not all nodes have anything
+     * irreducible (such as NamedProducer, IdentityKeyedProducer, MergedProducer, etc...)
+     */
+    val oldIrrToNode: Map[Map[Any, Int], List[Producer[P, Any]]] = dependants.nodes.groupBy(transIrr)
+
+    /**
+     * Basically do a graph walk on the list of irreducibles for each node
+     */
+    val newNames: Map[Producer[P, Any], List[String]] = newDependants.nodes.map { n =>
+      val newNodeIrr = transIrr(n)
+      oldIrrToNode.get(newNodeIrr) match {
+        case Some(oldProdList) => // get the name in the original graph
+          // Find the longest list of names
+          val oldNames = oldProdList.map(dependants.namesOf(_)).maxBy(_.size)
+          n -> oldNames.map(_.id)
+        case None =>
+          val newLine = "\n"
+          sys.error(s"Node $n in the new node has no corresponding node in the original graph: ${tail}.\n" +
+            s"new: ${newNodeIrr}\n" +
+            s"old: ${oldIrrToNode.mkString(newLine)}")
+      }
+    }(breakOut)
+    (newNames, newTail)
   }
 }

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/StripNameTest.scala
@@ -101,4 +101,68 @@ class StripNameTest extends FunSuite {
     // The final stripped has no names:
     assert(strippedDeps.nodes.collect { case NamedProducer(_, _) => 1 }.sum == 0)
   }
+
+  test("Fan-out name test") {
+    /*
+     * Here are the irreducible items
+     */
+    val store0 = MMap[Int, Int]()
+    val store1 = MMap[Int, Int]()
+    val input = List(1, 2, 4)
+    val fn0 = { k: Int => Some((k % 2, k * k)) }
+    val fn1 = { k: Int => Some((k % 3, k * k * k)) }
+    // Here is the graph
+    val src = Producer.source[Memory, Int](input)
+    val nameSrc = src.name("source")
+    // branch1
+    val mapped0 = nameSrc.optionMap(fn0)
+    val summed0 = mapped0.name("map0").sumByKey(store0)
+    // branch2
+    val mapped1 = nameSrc.optionMap(fn1)
+    val summed1 = mapped1.name("map1").name("map1.1").sumByKey(store1)
+    val graph = summed0.name("sumByKey0").also(summed1.name("sumByKey1"))
+    val namedG = graph.name("also")
+    val deps = Dependants(namedG)
+    /*
+     * With fan-out, a total order on the lists is not defined.
+     * so we check that the given list is in sorted order where
+     * the partial ordering is defined.
+     */
+    def assertInitName(n: Producer[Memory, Any], s: List[String]) = {
+      val ordering = deps.namesOf(n).map(_.id).zipWithIndex.toMap
+      val order = Ordering.by(ordering)
+      assert(s.sorted(order) == s, s"not sorted: $s != ${s.sorted(order)}")
+    }
+
+    assertInitName(src, List("source", "map0", "sumByKey0"))
+    assertInitName(src, List("source", "map1", "sumByKey1", "also"))
+    assertInitName(src, List("source", "map1", "map1.1", "sumByKey1", "also"))
+    assertInitName(src, List("also"))
+    // the "also" name only goes up the right hand side
+    // because the output of the also only depends on the right hand side
+    assertInitName(mapped0, List("map0", "sumByKey0"))
+    assertInitName(mapped1, List("map1", "map1.1", "sumByKey1", "also"))
+    assertInitName(summed0, List("sumByKey0"))
+    assertInitName(summed1, List("sumByKey1", "also"))
+    assertInitName(graph, List("also"))
+
+    val (nameMap, stripped) = StripNamedNode(namedG)
+    val strippedDeps = Dependants(stripped)
+
+    def assertName(names: List[String])(p: PartialFunction[Producer[Memory, Any], Producer[Memory, Any]]): Unit = {
+      val nodes = strippedDeps.nodes.collect(p)
+      assert(nodes.size == 1) // Only one node
+      val ordering = nameMap(nodes(0)).zipWithIndex.toMap
+      val order = Ordering.by(ordering)
+      assert(names.sorted(order) == names, s"not sorted: $names != ${names.sorted(order)}")
+    }
+    assertName(List("source", "map0", "sumByKey0")) { case p @ Source(l) if l == input => p }
+    assertName(List("source", "map1", "map1.1", "sumByKey1", "also")) { case p @ Source(l) if l == input => p }
+    assertName(List("map0", "sumByKey0")) { case p @ OptionMappedProducer(_, f) if f == fn0 => p }
+    assertName(List("map1", "sumByKey1", "also")) { case p @ OptionMappedProducer(_, f) if f == fn1 => p }
+    assertName(List("sumByKey0")) { case p @ Summer(_, str, _) if str eq store0 => p }
+    assertName(List("sumByKey1", "also")) { case p @ Summer(_, str, _) if str eq store1 => p }
+    // The final stripped has no names:
+    assert(strippedDeps.nodes.collect { case NamedProducer(_, _) => 1 }.sum == 0)
+  }
 }


### PR DESCRIPTION
This reverts #610 except with simpler, and much better tested code (which is to say, actual tests and tests which exposed bugs).

This adds more tests, for e.g. #633

This does not yet enable turning on all the optimizations + naming, as you have to be more careful about "irreducibles", which can change under some optimizations (namely, composing functions). But it is enough to remove the code duplication between StripNameNodes and the DagOptimizer which can do the same thing in a type-safe and general way.

I'd like to get this merged, then tackle keeping names correct under general optimizations, which I think is possible. This will dramatically simplify implementing platforms if we can successfully get the optimizations + names working correctly.

Of course, the names could control potentially optimizations (since named options can be options for optimizations), but we can deal with that down the line (probably, by passing the options into the dag optimizer).
