### PR TITLE
Add a test for redundant also in Memory platform

### DIFF
--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/memory/MemoryLaws.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/memory/MemoryLaws.scala
@@ -202,6 +202,18 @@ class MemoryLaws extends WordSpec {
     "lookupCollect w/ Int, Int" in { assert(lookupCollectChecker[Int, Int] == true) }
 
     "counters w/ Int, Int, Int" in { assert(counterChecker[Int, Int, Int] == true) }
+
+    "needless also shouldn't cause a problem" in {
+      val source = Memory.toSource(0 to 100)
+      val store1 = MutableMap.empty[Int, Int]
+      val store2 = MutableMap.empty[Int, Int]
+      val comp = source.map(v => (v % 3, v)).sumByKey(store1)
+      val prod = comp.also(comp.mapValues(_._2).write(new BufferFunc).sumByKey(store2))
+      val mem = new Memory
+      mem.run(mem.plan(prod))
+      assert(store1.toMap == ((0 to 100).groupBy(_ % 3).mapValues(_.sum)))
+      assert(store2.toMap == ((0 to 100).groupBy(_ % 3).mapValues(_.sum)))
+    }
   }
 
 }

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
@@ -72,6 +72,13 @@ class Memory(implicit jobID: JobId = JobId("default.memory.jobId")) extends Plat
                 fn(k).map((_, v))
             }, m)
 
+          case ValueFlatMappedProducer(producer, fn) =>
+            val (s, m) = toStream(producer, jamfs)
+            (s.flatMap {
+              case (k, v) =>
+                fn(v).map((k, _))
+            }, m)
+
           case AlsoProducer(l, r) =>
             //Plan the first one, but ignore it
             val (left, leftM) = toStream(l, jamfs)


### PR DESCRIPTION
I tried to reproduce #631 but could not.

I wonder if this was actually user error, and we didn't notice.

I guess we should add this test, but it already passes.

Fixed a warning of a missing case match in MemoryPlatform, but we're not testing flatMapValues, obviously, since it has never been triggered.