### PR TITLE
Remove catch Throwable, replace with NonFatal

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -34,6 +34,7 @@ import scala.collection.mutable.{ Map => MMap, ListBuffer }
 // These CMaps we generate in the FFM, we use it as an immutable wrapper around
 // a mutable map.
 import scala.collection.{ Map => CMap }
+import scala.util.control.NonFatal
 
 /**
  * @author Oscar Boykin
@@ -105,7 +106,7 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D, RC](
     sCache.tick.map(formatResult(_))
 
   def cache(state: S,
-    items: TraversableOnce[(Key, Value)]): Future[TraversableOnce[(Seq[S], Future[TraversableOnce[OutputElement]])]] = {
+    items: TraversableOnce[(Key, Value)]): Future[TraversableOnce[(Seq[S], Future[TraversableOnce[OutputElement]])]] =
     try {
       val itemL = items.toList
       if (itemL.size > 0) {
@@ -122,9 +123,8 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D, RC](
         )
       }
     } catch {
-      case t: Throwable => Future.exception(t)
+      case NonFatal(e) => Future.exception(e)
     }
-  }
 
   override def apply(state: S,
     tup: Event) =

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -29,6 +29,7 @@ import com.twitter.summingbird.option.CacheSize
 // These CMaps we generate in the FFM, we use it as an immutable wrapper around
 // a mutable map.
 import scala.collection.{ Map => CMap }
+import scala.util.control.NonFatal
 
 /**
  * The SummerBolt takes two related options: CacheSize and MaxWaitingFutures.
@@ -120,7 +121,7 @@ class Summer[Key, Value: Semigroup, Event, S, D, RC](
 
       sSummer.addAll(cacheEntries).map(handleResult(_))
     } catch {
-      case t: Throwable => Future.exception(t)
+      case NonFatal(e) => Future.exception(e)
     }
   }
 

--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingStatProvider.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingStatProvider.scala
@@ -5,6 +5,7 @@ import com.twitter.scalding.{ RuntimeStats => ScaldingRuntimeStats, UniqueID }
 import com.twitter.summingbird.option.JobId
 import com.twitter.summingbird._
 import scala.util.{ Try => ScalaTry, Failure }
+import scala.util.control.NonFatal
 import org.slf4j.LoggerFactory
 
 // Incrementor for Scalding Counter (Stat)
@@ -19,7 +20,7 @@ private[summingbird] object ScaldingStatProvider extends PlatformStatProvider {
   private def pullInScaldingRuntimeForJobID(jobID: JobId): Option[FlowProcess[_]] =
     ScalaTry[FlowProcess[_]] { ScaldingRuntimeStats.getFlowProcessForUniqueId(UniqueID(jobID.get)) }
       .recoverWith {
-        case e: Throwable =>
+        case NonFatal(e) =>
           logger.debug(s"Unable to get Scalding FlowProcess for jobID $jobID, error $e")
           Failure(e)
       }.toOption


### PR DESCRIPTION
It's possible this is hiding OOM errors in some cases. We really shouldn't catch OOM or linkage errors.