### PR TITLE
Make summingbird-storm compile with storm 0.10.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,10 @@ object SummingbirdBuild extends Build {
   val tormentaVersion = "0.11.0"
   val junitVersion = "4.11"
   val log4jVersion = "1.2.16"
-  val stormVersion = "0.9.0-wip15"
+  val stormDep = "storm" % "storm" % "0.9.0-wip15"
+  //This project also compiles with the latest storm, which is in fact required to run the example
+  //now. :/
+  //val stormDep = "org.apache.storm" % "storm-core" % "0.10.0"
   val commonsLangVersion = "2.6"
   val novocodeJunitVersion = "0.10"
   val scalatestVersion = "2.2.4"
@@ -251,7 +254,7 @@ object SummingbirdBuild extends Build {
       "com.twitter" %% "scalding-args" % scaldingVersion,
       "com.twitter" %% "tormenta-core" % tormentaVersion,
       "com.twitter" %% "util-core" % utilVersion,
-      "storm" % "storm" % stormVersion % "provided"
+      stormDep % "provided"
     )
   ).dependsOn(
     summingbirdCore % "test->test;compile->compile",
@@ -269,7 +272,7 @@ object SummingbirdBuild extends Build {
       "com.twitter" %% "storehaus-algebra" % storehausVersion,
       "com.twitter" %% "tormenta-core" % tormentaVersion,
       "com.twitter" %% "util-core" % utilVersion,
-      "storm" % "storm" % stormVersion % "provided"
+      stormDep % "provided"
     )
   ).dependsOn(
     summingbirdCore % "test->test;compile->compile",
@@ -330,7 +333,7 @@ object SummingbirdBuild extends Build {
 
   lazy val summingbirdBuilder = module("builder").settings(
     libraryDependencies ++= Seq(
-      "storm" % "storm" % stormVersion % "provided",
+      stormDep % "provided",
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided"
     )
   ).dependsOn(
@@ -343,7 +346,7 @@ object SummingbirdBuild extends Build {
     libraryDependencies ++= Seq(
       "log4j" % "log4j" % log4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
-      "storm" % "storm" % stormVersion exclude("org.slf4j", "log4j-over-slf4j") exclude("ch.qos.logback", "logback-classic"),
+      stormDep exclude("org.slf4j", "log4j-over-slf4j") exclude("ch.qos.logback", "logback-classic"),
       "com.twitter" %% "bijection-netty" % bijectionVersion,
       "com.twitter" %% "tormenta-twitter" % tormentaVersion,
       "com.twitter" %% "storehaus-memcache" % storehausVersion exclude("com.twitter.common", "dynamic-host-set") exclude("com.twitter.common", "service-thrift"),

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
@@ -41,11 +41,11 @@ object BuildSummer {
 
   def apply(storm: Storm, dag: Dag[Storm], node: StormNode, jobID: JobId) = {
     val opSummerConstructor = storm.get[SummerConstructor](dag, node).map(_._2)
-    logger.debug("Node ({}): Queried for SummerConstructor, got {}", dag.getNodeName(node), opSummerConstructor)
+    logger.debug(s"Node (${dag.getNodeName(node)}): Queried for SummerConstructor, got $opSummerConstructor")
 
     opSummerConstructor match {
       case Some(cons) =>
-        logger.debug("Node ({}): Using user supplied SummerConstructor: {}", dag.getNodeName(node), cons)
+        logger.debug(s"Node (${dag.getNodeName(node)}): Using user supplied SummerConstructor: $cons")
         cons.get
       case None => legacyBuilder(storm, dag, node, jobID)
     }
@@ -55,7 +55,7 @@ object BuildSummer {
     val nodeName = dag.getNodeName(node)
     val cacheSize = storm.getOrElse(dag, node, DEFAULT_FM_CACHE)
     require(jobID.get != null, "Unable to register metrics with no job id present in the config updater")
-    logger.info("[{}] cacheSize lowerbound: {}", nodeName, cacheSize.lowerBound)
+    logger.info(s"[$nodeName] cacheSize lowerbound: ${cacheSize.lowerBound}")
 
     val memoryCounter = counter(jobID, Group(nodeName), Name("memory"))
     val timeoutCounter = counter(jobID, Group(nodeName), Name("timeout"))
@@ -73,13 +73,13 @@ object BuildSummer {
       }
     } else {
       val softMemoryFlush = storm.getOrElse(dag, node, DEFAULT_SOFT_MEMORY_FLUSH_PERCENT)
-      logger.info("[{}] softMemoryFlush : {}", nodeName, softMemoryFlush.get)
+      logger.info(s"[$nodeName] softMemoryFlush : ${softMemoryFlush.get}")
 
       val flushFrequency = storm.getOrElse(dag, node, DEFAULT_FLUSH_FREQUENCY)
-      logger.info("[{}] maxWaiting: {}", nodeName, flushFrequency.get)
+      logger.info(s"[$nodeName] maxWaiting: ${flushFrequency.get}")
 
       val useAsyncCache = storm.getOrElse(dag, node, DEFAULT_USE_ASYNC_CACHE)
-      logger.info("[{}] useAsyncCache : {}", nodeName, useAsyncCache.get)
+      logger.info(s"[$nodeName] useAsyncCache : ${useAsyncCache.get}")
 
       if (!useAsyncCache.get) {
         new SummerBuilder {
@@ -98,10 +98,10 @@ object BuildSummer {
         }
       } else {
         val asyncPoolSize = storm.getOrElse(dag, node, DEFAULT_ASYNC_POOL_SIZE)
-        logger.info("[{}] asyncPoolSize : {}", nodeName, asyncPoolSize.get)
+        logger.info(s"[$nodeName] asyncPoolSize : ${asyncPoolSize.get}")
 
         val valueCombinerCrushSize = storm.getOrElse(dag, node, DEFAULT_VALUE_COMBINER_CACHE_SIZE)
-        logger.info("[{}] valueCombinerCrushSize : {}", nodeName, valueCombinerCrushSize.get)
+        logger.info(s"[$nodeName] valueCombinerCrushSize : ${valueCombinerCrushSize.get}")
 
         new SummerBuilder {
           def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
@@ -45,16 +45,16 @@ import scala.collection.{ Map => CMap }
  */
 object FlatMapBoltProvider {
   @transient private val logger = LoggerFactory.getLogger(FlatMapBoltProvider.getClass)
-  private def wrapTimeBatchIDKV[T, K, V](existingOp: FlatMapOperation[T, (K, V)])(batcher: Batcher): FlatMapOperation[(Timestamp, T), ((K, BatchID), (Timestamp, V))] = {
-    FlatMapOperation.generic({
-      case (ts: Timestamp, data: T) =>
+  private def wrapTimeBatchIDKV[T, K, V](existingOp: FlatMapOperation[T, (K, V)])(batcher: Batcher): FlatMapOperation[(Timestamp, T), ((K, BatchID), (Timestamp, V))] =
+    FlatMapOperation.generic[(Timestamp, T), ((K, BatchID), (Timestamp, V))]({
+      case (ts, data) =>
         existingOp.apply(data).map { vals =>
-          vals.map { tup =>
-            ((tup._1, batcher.batchOf(ts)), (ts, tup._2))
+          vals.map {
+            case (k, v) =>
+              ((k, batcher.batchOf(ts)), (ts, v))
           }
         }
     })
-  }
 
   def wrapTime[T, U](existingOp: FlatMapOperation[T, U]): FlatMapOperation[(Timestamp, T), (Timestamp, U)] = {
     FlatMapOperation.generic({ x: (Timestamp, T) =>
@@ -75,20 +75,20 @@ case class FlatMapBoltProvider(storm: Storm, jobID: JobId, stormDag: Dag[Storm],
   private val nodeName = stormDag.getNodeName(node)
   private val metrics = getOrElse(DEFAULT_FM_STORM_METRICS)
   private val anchorTuples = getOrElse(AnchorTuples.default)
-  logger.info("[{}] Anchoring: {}", nodeName, anchorTuples.anchor)
+  logger.info(s"[$nodeName] Anchoring: ${anchorTuples.anchor}")
 
   private val maxWaiting = getOrElse(DEFAULT_MAX_WAITING_FUTURES)
   private val maxWaitTime = getOrElse(DEFAULT_MAX_FUTURE_WAIT_TIME)
-  logger.info("[{}] maxWaiting: {}", nodeName, maxWaiting.get)
+  logger.info(s"[$nodeName] maxWaiting: ${maxWaiting.get}")
 
   private val ackOnEntry = getOrElse(DEFAULT_ACK_ON_ENTRY)
-  logger.info("[{}] ackOnEntry : {}", nodeName, ackOnEntry.get)
+  logger.info(s"[$nodeName] ackOnEntry : ${ackOnEntry.get}")
 
   val maxExecutePerSec = getOrElse(DEFAULT_MAX_EXECUTE_PER_SEC)
-  logger.info("[{}] maxExecutePerSec : {}", nodeName, maxExecutePerSec.toString)
+  logger.info(s"[$nodeName] maxExecutePerSec : $maxExecutePerSec")
 
   private val maxEmitPerExecute = getOrElse(DEFAULT_MAX_EMIT_PER_EXECUTE)
-  logger.info("[{}] maxEmitPerExecute : {}", nodeName, maxEmitPerExecute.get)
+  logger.info(s"[$nodeName] maxEmitPerExecute : ${maxEmitPerExecute.get}")
 
   private def getFFMBolt[T, K, V](summer: SummerNode[Storm]) = {
     type ExecutorInput = (Timestamp, T)
@@ -108,7 +108,7 @@ case class FlatMapBoltProvider(storm: Storm, jobID: JobId, stormDag: Dag[Storm],
 
     // This option we report its value here, but its not user settable.
     val keyValueShards = executor.KeyValueShards(summerParalellism.parHint * summerBatchMultiplier.get)
-    logger.info("[{}] keyValueShards : {}", nodeName, keyValueShards.get)
+    logger.info(s"[$nodeName] keyValueShards : ${keyValueShards.get}")
 
     val operation = foldOperations[T, (K, V)](node.members.reverse)
     val wrappedOperation = wrapTimeBatchIDKV(operation)(batcher)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -150,7 +150,7 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
   private def scheduleFlatMapper(jobID: JobId, stormDag: Dag[Storm], node: StormNode)(implicit topologyBuilder: TopologyBuilder) = {
     val nodeName = stormDag.getNodeName(node)
     val usePreferLocalDependency = getOrElse(stormDag, node, DEFAULT_FM_PREFER_LOCAL_DEPENDENCY)
-    logger.info("[{}] usePreferLocalDependency: {}", nodeName, usePreferLocalDependency.get)
+    logger.info(s"[$nodeName] usePreferLocalDependency: ${usePreferLocalDependency.get}")
 
     val bolt: BaseBolt[Any, Any] = FlatMapBoltProvider(this, jobID, stormDag, node).apply
 
@@ -226,13 +226,13 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
     val builder = BuildSummer(this, stormDag, node, jobID)
 
     val ackOnEntry = getOrElse(stormDag, node, DEFAULT_ACK_ON_ENTRY)
-    logger.info("[{}] ackOnEntry : {}", nodeName, ackOnEntry.get)
+    logger.info(s"[$nodeName] ackOnEntry : ${ackOnEntry.get}")
 
     val maxEmitPerExecute = getOrElse(stormDag, node, DEFAULT_MAX_EMIT_PER_EXECUTE)
-    logger.info("[{}] maxEmitPerExecute : {}", nodeName, maxEmitPerExecute.get)
+    logger.info(s"[$nodeName] maxEmitPerExecute : ${maxEmitPerExecute.get}")
 
     val maxExecutePerSec = getOrElse(stormDag, node, DEFAULT_MAX_EXECUTE_PER_SEC)
-    logger.info("[{}] maxExecutePerSec : {}", nodeName, maxExecutePerSec.toString)
+    logger.info(s"[$nodeName] maxExecutePerSec : $maxExecutePerSec")
 
     val storeBaseFMOp = { op: (ExecutorKeyType, (Option[ExecutorValueType], ExecutorValueType)) =>
       val ((k, batchID), (optiVWithTS, (ts, v))) = op


### PR DESCRIPTION
Did this to address #643. Had to make a few changes due to slf4j changes that I guess get pulled in transitively (man, transitive deps are kind of a broken idea, I'm afraid, who knows what other versions get bumped with this change?).

The real issue is that storm 0.9.0-wip15 was using an old zookeeper that is incompatible with recent finagle, which is also used in the examples. The solution to #643 then is to upgrade storm to get on a compatible zookeeper.