### PR TITLE
Fix outstanding futures clear bottleneck

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -94,8 +94,8 @@ abstract class AsyncBase[I, O, S, D, RC](maxWaitingFutures: MaxWaitingFutures, m
   private def addOutstandingFuture(fut: Future[Unit]): Boolean =
     if (!fut.isDefined) {
       outstandingFutures.put(fut)
-      numPendingOutstandingFutures.addAndGet(1)
-      fut.respond { _ => numPendingOutstandingFutures.addAndGet(-1) }
+      numPendingOutstandingFutures.incrementAndGet
+      fut.ensure(numPendingOutstandingFutures.decrementAndGet)
       true
     } else {
       false


### PR DESCRIPTION
When maxWaitingFutures is high, AsyncBase can end up spending a lot of compute just clearing finished futures. The cost of clearing the finished futures is proportional to total number of outstanding futures.  If the number of finished futures is very low compared to total outstanding then we can end up paying this price for nothing much. And the same pattern can repeat on every execute. I found this happening in one of the jobs. In this change we keep track of number of pending futures and use that info to make sure that we clear the finished futures only when they are a good proportion of total number of outstanding futures so that we get good return on investment.
