### PR TITLE
Fix root cause of duplicate summer execution in Memory platform

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
@@ -46,7 +46,7 @@ class Memory(implicit jobID: JobId = JobId("default.memory.jobId")) extends Plat
   def counter(group: Group, name: Name): Option[Long] =
     MemoryStatProvider.getCountersForJob(jobID).flatMap { _.get(group.getString + "/" + name.getString).map { _.get } }
 
-  def toStream[T, K, V](outerProducer: Prod[T], jamfs: JamfMap): (Stream[T], JamfMap) =
+  def toStream[T](outerProducer: Prod[T], jamfs: JamfMap): (Stream[T], JamfMap) =
     Option(jamfs.get(outerProducer)) match {
       case Some(s) => (s.asInstanceOf[Stream[T]], jamfs)
       case None =>

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
@@ -16,8 +16,10 @@
 
 package com.twitter.summingbird.memory
 
+import java.util
+
+import com.twitter.algebird.Monoid
 import com.twitter.summingbird._
-import com.twitter.summingbird.graph.HMap
 import com.twitter.summingbird.option.JobId
 import com.twitter.summingbird.planner.DagOptimizer
 import collection.mutable.{ Map => MutableMap }
@@ -39,82 +41,85 @@ class Memory(implicit jobID: JobId = JobId("default.memory.jobId")) extends Plat
   type Plan[T] = Stream[T]
 
   private type Prod[T] = Producer[Memory, T]
-  private type JamfMap = HMap[Prod, Stream]
+  private type JamfMap = util.IdentityHashMap[Prod[_], Stream[_]]
 
   def counter(group: Group, name: Name): Option[Long] =
     MemoryStatProvider.getCountersForJob(jobID).flatMap { _.get(group.getString + "/" + name.getString).map { _.get } }
 
-  private def toStream[T](outerProducer: Prod[T], jamfs: JamfMap): (Stream[T], JamfMap) =
-    jamfs.get(outerProducer) match {
-      case Some(s) => (s, jamfs)
-      case None =>
-        val (s, m) = outerProducer match {
-          case NamedProducer(producer, _) => toStream(producer, jamfs)
-          case IdentityKeyedProducer(producer) => toStream(producer, jamfs)
-          case Source(source) => (source.toStream, jamfs)
-          case OptionMappedProducer(producer, fn) =>
-            val (s, m) = toStream(producer, jamfs)
-            (s.flatMap(fn(_)), m)
+  def toStream[T, K, V](outerProducer: Prod[T], jamfs: JamfMap): (Stream[T], JamfMap) = {
+    val stream = jamfs.get(outerProducer)
+    if (stream != null) {
+      (stream.asInstanceOf[Stream[T]], jamfs)
+    } else {
+      val (s, m) = outerProducer match {
+        case NamedProducer(producer, _) => toStream(producer, jamfs)
+        case IdentityKeyedProducer(producer) => toStream(producer, jamfs)
+        case Source(source) => (source.toStream, jamfs)
+        case OptionMappedProducer(producer, fn) =>
+          val (s, m) = toStream(producer, jamfs)
+          (s.flatMap(fn(_)), m)
 
-          case FlatMappedProducer(producer, fn) =>
-            val (s, m) = toStream(producer, jamfs)
-            (s.flatMap(fn(_)), m)
+        case FlatMappedProducer(producer, fn) =>
+          val (s, m) = toStream(producer, jamfs)
+          (s.flatMap(fn(_)), m)
 
-          case MergedProducer(l, r) =>
-            val (leftS, leftM) = toStream(l, jamfs)
-            val (rightS, rightM) = toStream(r, leftM)
-            (leftS ++ rightS, rightM)
+        case MergedProducer(l, r) =>
+          val (leftS, leftM) = toStream(l, jamfs)
+          val (rightS, rightM) = toStream(r, leftM)
+          (leftS ++ rightS, rightM)
 
-          case KeyFlatMappedProducer(producer, fn) =>
-            val (s, m) = toStream(producer, jamfs)
-            (s.flatMap {
-              case (k, v) =>
-                fn(k).map((_, v))
-            }, m)
+        case KeyFlatMappedProducer(producer, fn) =>
+          val (s, m) = toStream(producer, jamfs)
+          (s.flatMap {
+            case (k, v) =>
+              fn(k).map((_, v))
+          }, m)
 
-          case ValueFlatMappedProducer(producer, fn) =>
-            val (s, m) = toStream(producer, jamfs)
-            (s.flatMap {
-              case (k, v) =>
-                fn(v).map((k, _))
-            }, m)
+        case ValueFlatMappedProducer(producer, fn) =>
+          val (s, m) = toStream(producer, jamfs)
+          (s.flatMap {
+            case (k, v) =>
+              fn(v).map((k, _))
+          }, m)
 
-          case AlsoProducer(l, r) =>
-            //Plan the first one, but ignore it
-            val (left, leftM) = toStream(l, jamfs)
-            val (right, rightM) = toStream(r, leftM)
-            // We need to force all of left to make sure any
-            // side effects in write happen
-            lazy val lforcedEmpty = left.filter(_ => false)
-            (right.append(lforcedEmpty), rightM)
+        case AlsoProducer(l, r) =>
+          //Plan the first one, but ignore it
+          val (left, leftM) = toStream(l, jamfs)
+          // We need to force all of left to make sure any
+          // side effects in write happen
+          val lforcedEmpty = left.filter(_ => false)
+          val (right, rightM) = toStream(r, leftM)
+          (right ++ lforcedEmpty, rightM)
 
-          case WrittenProducer(producer, fn) =>
-            val (s, m) = toStream(producer, jamfs)
-            (s.map { i => fn(i); i }, m)
+        case WrittenProducer(producer, fn) =>
+          val (s, m) = toStream(producer, jamfs)
+          (s.map { i => fn(i); i }, m)
 
-          case LeftJoinedProducer(producer, service) =>
-            val (s, m) = toStream(producer, jamfs)
-            val joined = s.map {
-              case (k, v) => (k, (v, service.get(k)))
-            }
-            (joined, m)
+        case LeftJoinedProducer(producer, service) =>
+          val (s, m) = toStream(producer, jamfs)
+          val joined = s.map {
+            case (k, v) => (k, (v, service.get(k)))
+          }
+          (joined, m)
 
-          case Summer(producer, store, semigroup) =>
-            val (s, m) = toStream(producer, jamfs)
-            val summed = s.map {
-              case (k, deltaV) =>
-                val oldV = store.get(k)
-                val newV = oldV.map { semigroup.plus(_, deltaV) }
-                  .getOrElse(deltaV)
-                store.update(k, newV)
-                (k, (oldV, deltaV))
-            }
-            (summed, m)
-        }
-        // scala can't infer that s is the right type through case statements above
-        val st = s.asInstanceOf[Stream[T]]
-        (st, m + (outerProducer -> st))
+        case Summer(producer, store, monoid) =>
+          val (s, m) = toStream(producer, jamfs)
+          val summed = s.map {
+            case pair @ (k, deltaV) =>
+              val oldV = store.get(k)
+              val newV = oldV.map {
+                monoid.plus(_, deltaV)
+              }
+                .getOrElse(deltaV)
+              store.update(k, newV)
+              (k, (oldV, deltaV))
+          }
+          (summed, m)
+      }
+      m.put(outerProducer, s)
+      (s.asInstanceOf[Stream[T]], m)
     }
+  }
 
   def plan[T](prod: TailProducer[Memory, T]): Stream[T] = {
 
@@ -130,7 +135,7 @@ class Memory(implicit jobID: JobId = JobId("default.memory.jobId")) extends Plat
     val memoryTail = dagOptimizer.optimize(prod, dagOptimizer.ValueFlatMapToFlatMap)
     val memoryDag = memoryTail.asInstanceOf[TailProducer[Memory, T]]
 
-    toStream(memoryDag, HMap.empty)._1
+    toStream(memoryDag, new JamfMap)._1
   }
 
   def run(iter: Stream[_]) {

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
@@ -101,13 +101,13 @@ class Memory(implicit jobID: JobId = JobId("default.memory.jobId")) extends Plat
             }
             (joined, m)
 
-          case Summer(producer, store, monoid) =>
+          case Summer(producer, store, semigroup) =>
             val (s, m) = toStream(producer, jamfs)
             val summed = s.map {
-              case pair @ (k, deltaV) =>
+              case (k, deltaV) =>
                 val oldV = store.get(k)
                 val newV = oldV.map {
-                  monoid.plus(_, deltaV)
+                  semigroup.plus(_, deltaV)
                 }
                   .getOrElse(deltaV)
                 store.update(k, newV)

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/memory/Memory.scala
@@ -16,9 +16,6 @@
 
 package com.twitter.summingbird.memory
 
-import java.util
-
-import com.twitter.algebird.Monoid
 import com.twitter.summingbird._
 import com.twitter.summingbird.graph.HMap
 import com.twitter.summingbird.option.JobId


### PR DESCRIPTION
AlsoProducers. The root cause has actually to do with the summer. In
toStream method we keep a map of Producer to stream to make sure we don't run
parts of the graph again and again. The map uses value equality. The
problem is that summer includes store which is mutable. If a summer is
referenced by two also producers and if by the time summer is revisited
the store has changed then the key would be different from the original
summer and won't be found in the map, leading to the summer being
planned again. d3b5808 seems to fix the issue and passes a unit test
because that test has only one AlsoProducer, where planning left and
right before forcing left means that store doesn't change in between.
But it likely wouldn't fix the case where there are multiple AlsoProducers at
different levels. Even if it did fix those cases this is an indirect
solution and it's better to avoid taking any chances and fix the root of
the issue.

This is a case where reference equality fits the bill. I don't know of
an immutable implementation of a map that uses reference equality so
I'm using java.util.IdentityHashMap, if there is one I would love to use
that instead.
