### PR TITLE
Add Sam Ritchie as a COMMITTER

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -14,6 +14,7 @@ Please see our [Project Governance](https://github.com/twitter/analytics-infra-g
 | Pankaj Gupta           | [@pankajroark](https://github.com/pankajroark)            |
 | Piyush Narang          | [@piyushnarang](https://github.com/piyushnarang)          |
 | Ruban Monu             | [@rubanm](https://github.com/rubanm)                      |
+| Sam Ritchie            | [@sritchie](https://github.com/sritchie)                  |
 | Sriram Krishnan        | [@sriramkrishnan](https://github.com/sriramkrishnan)      |
 
 ##Emeritus


### PR DESCRIPTION
I think it was an oversight to not include Sam as one of the original COMMITTERs in summingbird, so this PR adds him.

I don't think a vote is necessary, as we did not vote on the original set of COMMITTERS, but after this, I think we can consider the original 'grandfathered' committers to be closed and all other committers should go through a vote (which is not a difficult process, so if we missed somebody obvious, we can vote, it'll pass, and that'll be that).
