### PR TITLE
Pass the semigroup to create Mergeable online

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/MergeableStoreFactory.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/MergeableStoreFactory.scala
@@ -39,10 +39,8 @@ object MergeableStoreFactory {
       def mergeableBatcher = batcher
     }
 
-  def fromOnlineOnly[K, V](store: => MergeableStore[K, V]): MergeableStoreFactory[(K, BatchID), V] = {
-    implicit val batcher = Batcher.unit
-    from(store.convert { k: (K, BatchID) => k._1 })
-  }
+  def fromOnlineOnly[K, V](store: => MergeableStore[K, V]): MergeableStoreFactory[(K, BatchID), V] =
+    fromOnlineOnlyWithSemigroup(_ => store)
 
   def fromOnlineOnlyWithSemigroup[K, V](fn: Semigroup[V] => MergeableStore[K, V]): MergeableStoreFactory[(K, BatchID), V] =
     fromWithSemigroup(fn.andThen(_.convert { k: (K, BatchID) => k._1 }))(Batcher.unit)

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/MergeableStoreFactory.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/MergeableStoreFactory.scala
@@ -16,6 +16,7 @@
 
 package com.twitter.summingbird.online
 
+import com.twitter.algebird.Semigroup
 import com.twitter.storehaus.algebra.{ MergeableStore, Mergeable, StoreAlgebra }
 import com.twitter.summingbird.batch.{ Batcher, BatchID }
 
@@ -26,23 +27,28 @@ import com.twitter.summingbird.batch.{ Batcher, BatchID }
  */
 object MergeableStoreFactory {
 
-  def apply[K, V](store: () => Mergeable[K, V], batcher: Batcher) = {
-    new MergeableStoreFactory[K, V] {
-      def mergeableStore = store
-      def mergeableBatcher = batcher
-    }
-  }
+  def apply[K, V](store: () => Mergeable[K, V], batcher: Batcher) =
+    fromWithSemigroup { _: Semigroup[V] => store() }(batcher)
 
   def from[K, V](store: => Mergeable[(K, BatchID), V])(implicit batcher: Batcher): MergeableStoreFactory[(K, BatchID), V] =
-    apply({ () => store }, batcher)
+    fromWithSemigroup(_ => store)
+
+  def fromWithSemigroup[K, V](fn: Semigroup[V] => Mergeable[K, V])(implicit batcher: Batcher): MergeableStoreFactory[K, V] =
+    new MergeableStoreFactory[K, V] {
+      def mergeableStore = fn
+      def mergeableBatcher = batcher
+    }
 
   def fromOnlineOnly[K, V](store: => MergeableStore[K, V]): MergeableStoreFactory[(K, BatchID), V] = {
     implicit val batcher = Batcher.unit
     from(store.convert { k: (K, BatchID) => k._1 })
   }
+
+  def fromOnlineOnlyWithSemigroup[K, V](fn: Semigroup[V] => MergeableStore[K, V]): MergeableStoreFactory[(K, BatchID), V] =
+    fromWithSemigroup(fn.andThen(_.convert { k: (K, BatchID) => k._1 }))(Batcher.unit)
 }
 
 trait MergeableStoreFactory[-K, V] extends java.io.Serializable {
-  def mergeableStore: () => Mergeable[K, V]
+  def mergeableStore: Semigroup[V] => Mergeable[K, V]
   def mergeableBatcher: Batcher
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/WrappedTSInMergeable.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/WrappedTSInMergeable.scala
@@ -41,22 +41,3 @@ class WrappedTSInMergeable[K, V](self: Mergeable[K, V]) extends Mergeable[K, (Ti
         })
     }
 }
-
-object MergeableStoreFactoryAlgebra {
-  /*
-      Our tuples that we hand to the store are of the form ((K, BatchID), (Timestamp, V))
-      but in our store we only store ((K, BatchID), V). That is we don't include the timestamp.
-      We need these timestamps to continue processing downstream however, so we use a Right timestamp to say
-      the last value is taken. (Which may not be the max(TS)).
-
-      The merge operation here takes the inbound value of (Timestamp, V), performs the inner merge from the store.
-      Then looks back up the timestamp handed from the stream and outputs with that.
-      */
-  def wrapOnlineFactory[K, V](supplier: MergeableStoreFactory[K, V]): MergeableStoreFactory[K, (Timestamp, V)] =
-    {
-      val mergeable: () => Mergeable[K, (Timestamp, V)] =
-        () => { new WrappedTSInMergeable(supplier.mergeableStore()) }
-
-      MergeableStoreFactory[K, (Timestamp, V)](mergeable, supplier.mergeableBatcher)
-    }
-}

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -55,7 +55,7 @@ import scala.util.control.NonFatal
  */
 
 class Summer[Key, Value: Semigroup, Event, S, D, RC](
-  @transient storeSupplier: MergeableStoreFactory[Key, Value],
+  @transient storeSupplier: () => Mergeable[Key, Value],
   @transient flatMapOp: FlatMapOperation[(Key, (Option[Value], Value)), Event],
   @transient successHandler: OnlineSuccessHandler,
   @transient exceptionHandler: OnlineExceptionHandler,
@@ -86,7 +86,7 @@ class Summer[Key, Value: Semigroup, Event, S, D, RC](
 
   override def init(runtimeContext: RC) {
     super.init(runtimeContext)
-    storePromise.setValue(storeBox.get.mergeableStore())
+    storePromise.setValue(storeBox.get())
     store.toString // Do the lazy evaluation now so we can connect before tuples arrive.
 
     successHandlerOpt = if (includeSuccessHandler.get) Some(successHandlerBox.get) else None


### PR DESCRIPTION
closes #677

The issue is that it is easy to have the semigroup get out of sync between the `implicit` semigroup in the `Producer` graph, and the captured value for storm. This is not totally fixed, since when using a single store as a service and a store, we still need to capture the semigroup, but `leftJoin` does not have access to that. We could fix that walking the graph and finding the semigroup at the location of the `sumByKey`. We can do that in a later PR.
