### PR TITLE
Increase default value to SummerBatchMultiplier

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/OnlineDefaultConstants.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/OnlineDefaultConstants.scala
@@ -43,7 +43,7 @@ private[summingbird] trait OnlineDefaultConstants {
   val DEFAULT_SOFT_MEMORY_FLUSH_PERCENT = SoftMemoryFlushPercent(80.0F)
   val DEFAULT_VALUE_COMBINER_CACHE_SIZE = ValueCombinerCacheSize(100)
   val DEFAULT_MAX_EMIT_PER_EXECUTE = MaxEmitPerExecute(Int.MaxValue)
-  val DEFAULT_SUMMER_BATCH_MULTIPLIER = SummerBatchMultiplier(1)
+  val DEFAULT_SUMMER_BATCH_MULTIPLIER = SummerBatchMultiplier(100)
   val DEFAULT_FM_MERGEABLE_WITH_SOURCE = FMMergeableWithSource.default
 
 }


### PR DESCRIPTION
Value of 1 means that we create the same number of keys as the number of downstream bolts. In such a scenario collisions are very common and some summer bolts end up getting double, triple the data and others don't get any data at all. Increasing this value means that the number of events sent downstream is more and thus reduces batching but practically we haven't seen that make much difference.

Practically almost every user runs into this skew, discovers this setting and most of the time they set it to a very high value like 10k. I think 100 is a much better default. 
