### PR TITLE
Aggregate message IDs with values in AggregatorOutputCollector

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
@@ -37,7 +37,7 @@ class AggregatorOutputCollector[K, V: Semigroup](
       if (iter.isEmpty) None else Some(iter.flatten)
   }
 
-  private def getSummer = summerBuilder.getSummer[K, (OutputMessageId, V)](implicitly[Semigroup[(OutputMessageId, V)]])
+  private def getSummer = summerBuilder.getSummer[K, (OutputMessageId, V)]
 
   /**
    * This method is invoked from the nextTuple() of the spout.

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
@@ -56,10 +56,10 @@ class AggregatorOutputCollector[K, V: Semigroup](
   private def convertToSummerInputFormat(flushedCache: Map[K, (OutputMessageId, V)]): TraversableOnce[OutputTuple] =
     flushedCache.groupBy {
       case (k, _) => summerShards.summerIdFor(k)
-    }.map {
-      case (index: AggKey, m: Map[K, (OutputMessageId, V)]) =>
-        val messageIds = m.values.iterator.flatMap { case (ids, _) => ids }
-        val results = m.mapValues { case (_, v) => v }
+    }.iterator.map {
+      case (index, data) =>
+        val messageIds = data.values.iterator.flatMap { case (ids, _) => ids }
+        val results = data.mapValues { case (_, v) => v }
         (index, results, messageIds)
     }
 

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollector.scala
@@ -1,15 +1,14 @@
 package com.twitter.summingbird.storm.collector
 
+import backtype.storm.spout.SpoutOutputCollector
 import com.twitter.algebird.Semigroup
 import com.twitter.summingbird.online.executor.KeyValueShards
 import com.twitter.summingbird.online.option.SummerBuilder
-import backtype.storm.spout.{ ISpoutOutputCollector, SpoutOutputCollector }
 import com.twitter.algebird.util.summer.{ AsyncSummer, Incrementor }
-import com.twitter.util.{ Await, Duration, Future, Time }
-import scala.collection.mutable.{ Map => MMap, MutableList => MList }
-import scala.collection.{ Map => CMap }
-import scala.collection.JavaConverters._
+import com.twitter.util.{ Await, Future, Time }
 import java.util.{ List => JList }
+import scala.collection.mutable.{ ListBuffer, Map => MMap }
+import scala.collection.JavaConverters._
 
 /**
  *
@@ -24,13 +23,13 @@ class AggregatorOutputCollector[K, V: Semigroup](
     flushExecTimeCounter: Incrementor,
     executeTimeCounter: Incrementor) extends SpoutOutputCollector(in) {
 
-  // An individual summer is created for each stream of data. This map keeps track of the stream and its corresponding summer.
-  private val cacheByStreamId = MMap[String, AsyncSummer[(K, V), Map[K, V]]]()
+  private type AggKey = Int
+  private type AggValue = Map[K, V]
+  private type OutputMessageId = TraversableOnce[Object]
+  private type OutputTuple = (AggKey, AggValue, OutputMessageId)
 
-  // As the crushDown happens at a stream level. We have a mapping from stream to the messageIds.
-  // The messageIds are further aggregated to the level of summerShards.
-  // The Map keeps track of aggregated tuples' messageIds as a list.
-  private val streamMessageIdTracker = MMap[String, MMap[Int, MList[Object]]]()
+  // An individual summer is created for each stream of data. This map keeps track of the stream and its corresponding summer.
+  private val cacheByStreamId = MMap.empty[String, AsyncSummer[(K, (Seq[Object], V)), Map[K, (Seq[Object], V)]]]
 
   /**
    * This method is invoked from the nextTuple() of the spout.
@@ -46,27 +45,33 @@ class AggregatorOutputCollector[K, V: Semigroup](
     flushExecTimeCounter.incrBy(Time.now.inMillis - startTime.inMillis)
   }
 
-  private def convertToSummerInputFormat(flushedCache: CMap[_, _]): CMap[Int, CMap[_, _]] =
-    flushedCache.groupBy { case (k, _) => summerShards.summerIdFor(k) }
+  private def convertToSummerInputFormat(flushedCache: Map[K, (Seq[Object], V)]): TraversableOnce[OutputTuple] =
+    flushedCache.groupBy {
+      case (k, _) => summerShards.summerIdFor(k)
+    }.map {
+      case (index: AggKey, m: Map[K, (OutputMessageId, V)]) =>
+        val messageIds = m.values.flatMap { case (ids, _) => ids }
+        val results = m.mapValues { case (_, v) => v }
+        (index, results, messageIds)
+    }
 
   /*
     The method is invoked to handle the flushed cache caused by
     exceeding the memoryLimit, which is called within add method.
    */
-  private def emitData(tuples: Future[TraversableOnce[(Int, CMap[_, _])]], streamId: String): JList[Integer] = {
+  private def emitData(tuples: Future[TraversableOnce[OutputTuple]], streamId: String): JList[Integer] = {
     val startTime = Time.now
+
     val flushedTups = Await.result(tuples)
-    val messageIdsTracker = streamMessageIdTracker.getOrElse(streamId, MMap[Int, MList[Object]]())
-    val returns = flushedTups.map {
-      case (k, v) =>
-        val messageIds = messageIdsTracker.remove(k)
-        val list = new java.util.ArrayList[AnyRef](2)
-        list.add(k.asInstanceOf[AnyRef])
-        list.add(v.asInstanceOf[AnyRef])
-        callEmit(messageIds, list, streamId)
-    }
     val result = new java.util.ArrayList[Integer]()
-    returns.filter(_ != null).foreach { result.addAll(_) }
+    flushedTups.foreach {
+      case (groupKey, data, messageIds) =>
+        val tuple = new java.util.ArrayList[AnyRef](2)
+        tuple.add(groupKey.asInstanceOf[AnyRef])
+        tuple.add(data.asInstanceOf[AnyRef])
+        val emitResult = callEmit(tuple, messageIds, streamId)
+        if (emitResult != null) result.addAll(emitResult)
+    }
     executeTimeCounter.incrBy(Time.now.inMillis - startTime.inMillis)
     result
   }
@@ -75,12 +80,12 @@ class AggregatorOutputCollector[K, V: Semigroup](
    This is a wrapper method to call the emit with appropriate signature
    based on the arguments.
   */
-  private def callEmit(messageIds: Option[TraversableOnce[AnyRef]], list: JList[AnyRef], stream: String): JList[Integer] = {
-    (messageIds, stream.isEmpty) match {
-      case (None, true) => in.emit(list)
-      case (None, false) => in.emit(stream, list)
-      case (Some(ids), true) => in.emit(list, ids)
-      case (Some(ids), false) => in.emit(stream, list, ids)
+  private def callEmit(tuple: JList[AnyRef], messageIds: TraversableOnce[AnyRef], stream: String): JList[Integer] = {
+    (messageIds.isEmpty, stream.isEmpty) match {
+      case (true, true) => in.emit(tuple)
+      case (true, false) => in.emit(stream, tuple)
+      case (false, true) => in.emit(tuple, messageIds)
+      case (false, false) => in.emit(stream, tuple, messageIds)
     }
   }
 
@@ -88,30 +93,11 @@ class AggregatorOutputCollector[K, V: Semigroup](
   Method wraps the adding the tuple to the spoutCache along with adding the corresponding
   messageId to the messageId Tracker.
    */
-  private def add(tuple: (K, V), streamid: String, messageId: Option[AnyRef] = None): Future[Map[K, V]] = {
-    if (messageId.isDefined)
-      trackMessageId(tuple, messageId.get, streamid)
-    addToCache(tuple, streamid)
-  }
-
-  /*
-   * As there are separate summers for each stream. This method takes care of the stream lookup
-   * and adding the tuple to the corresponding cache.
-   */
-  private def addToCache(tuple: (K, V), streamid: String): Future[Map[K, V]] = {
-    cacheByStreamId.getOrElseUpdate(streamid, summerBuilder.getSummer[K, V](implicitly[Semigroup[V]]))
-      .add(tuple)
-  }
-
-  /**
-   * The lookup of stream is followed by the lookup on summerShard happens.
-   * The messageId is added to the corresponding group.
-   * All the messageIds are sent along with the crushed tuple.
-   */
-  private def trackMessageId(tuple: (K, V), o: AnyRef, s: String): Unit = {
-    val messageIdTracker = streamMessageIdTracker.getOrElseUpdate(s, MMap[Int, MList[Object]]())
-    val messageIds = messageIdTracker.getOrElseUpdate(summerShards.summerIdFor(tuple._1), MList())
-    messageIds += o
+  private def add(tuple: (K, V), streamId: String, messageId: Option[AnyRef] = None): Future[Map[K, (Seq[Object], V)]] = {
+    val buffer = messageId.map { id => ListBuffer(id) }.getOrElse(Nil)
+    val (k, v) = tuple
+    cacheByStreamId.getOrElseUpdate(streamId, summerBuilder.getSummer[K, (Seq[Object], V)](implicitly[Semigroup[(Seq[Object], V)]]))
+      .add(k -> ((buffer, v)))
   }
 
   private def extractAndProcessElements(streamId: String, list: JList[AnyRef], messageId: Option[AnyRef] = None): JList[Integer] = {

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/spout/KeyValueSpout.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/spout/KeyValueSpout.scala
@@ -6,22 +6,24 @@ import backtype.storm.topology.{ IRichSpout, OutputFieldsDeclarer }
 import backtype.storm.tuple.Fields
 import com.twitter.algebird.Semigroup
 import com.twitter.algebird.util.summer.Incrementor
-import com.twitter.summingbird.online.Externalizer
 import com.twitter.summingbird.online.executor.KeyValueShards
 import com.twitter.summingbird.online.option.SummerBuilder
 import com.twitter.summingbird.storm.Constants._
 import com.twitter.tormenta.spout.SpoutProxy
-import java.util
-import java.util.{ List => JList }
-import scala.collection.mutable.{ MutableList => MList }
 import com.twitter.summingbird.storm.collector.AggregatorOutputCollector
 import com.twitter.util.{ Duration, Time }
+import java.util.{ Map => JMap }
 
 /**
  * This is a spout used when the spout is being followed by summer.
  * It uses a AggregatorOutputCollector on open.
  */
-class KeyValueSpout[K, V: Semigroup](val in: IRichSpout, summerBuilder: SummerBuilder, summerShards: KeyValueShards, flushExecTimeCounter: Incrementor, executeTimeCounter: Incrementor) extends SpoutProxy {
+class KeyValueSpout[K, V: Semigroup](
+    protected val self: IRichSpout,
+    summerBuilder: SummerBuilder,
+    summerShards: KeyValueShards,
+    flushExecTimeCounter: Incrementor,
+    executeTimeCounter: Incrementor) extends SpoutProxy {
 
   private final val tickFrequency = Duration.fromMilliseconds(1000)
   private var adapterCollector: AggregatorOutputCollector[K, V] = _
@@ -34,11 +36,11 @@ class KeyValueSpout[K, V: Semigroup](val in: IRichSpout, summerBuilder: SummerBu
   /**
    * On open the outputCollector is wrapped with AggregateOutputCollector and fed to the KeyValueSpout.
    */
-  override def open(conf: util.Map[_, _],
+  override def open(conf: JMap[_, _],
     topologyContext: TopologyContext,
     outputCollector: SpoutOutputCollector): Unit = {
     adapterCollector = new AggregatorOutputCollector(outputCollector, summerBuilder, summerShards, flushExecTimeCounter, executeTimeCounter)
-    in.open(conf, topologyContext, adapterCollector)
+    super.open(conf, topologyContext, adapterCollector)
   }
 
   /**
@@ -49,7 +51,7 @@ class KeyValueSpout[K, V: Semigroup](val in: IRichSpout, summerBuilder: SummerBu
       adapterCollector.timerFlush()
       lastDump = Time.now
     }
-    in.nextTuple()
+    super.nextTuple()
   }
 
   /**
@@ -69,6 +71,4 @@ class KeyValueSpout[K, V: Semigroup](val in: IRichSpout, summerBuilder: SummerBu
     val msgIds = msgId.asInstanceOf[TraversableOnce[AnyRef]]
     msgIds.foreach { super.fail(_) }
   }
-
-  override protected def self: IRichSpout = in
 }

--- a/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
+++ b/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
@@ -40,7 +40,7 @@ object TestKeyValueSpout {
 }
 class TestKeyValueSpout extends WordSpec {
 
-  def process(spout: Spout[(Timestamp, (Int, Int))], summer: SummerBuilder, expected: MSet[(Int, Map[_, _], Option[String], Option[Any])]) = {
+  def process(spout: Spout[(Timestamp, (Int, Int))], summer: SummerBuilder, expected: MSet[TestAggregateOutpoutCollector.ExpectedTuple]) = {
     val formattedSummerSpout = spout.map {
       case (time, (k, v)) => ((k, BatchID(1)), (time, v))
     }
@@ -63,7 +63,7 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    val expectedTuples = TestAggregateOutpoutCollector.emptyTupleSet
     expectedTuples.add((0, Map((1, BatchID(1)) -> ((timeStamp, 1)), (2, BatchID(1)) -> ((timeStamp, 1))), None, None))
     expectedTuples.add((0, Map((3, BatchID(1)) -> ((timeStamp, 1)), (4, BatchID(1)) -> ((timeStamp, 1))), None, None))
 
@@ -82,7 +82,7 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    val expectedTuples = TestAggregateOutpoutCollector.emptyTupleSet
     expectedTuples.add((0, Map((1, BatchID(1)) -> ((timeStamp, 6))), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
@@ -100,7 +100,7 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    val expectedTuples = TestAggregateOutpoutCollector.emptyTupleSet
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -117,7 +117,7 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    val expectedTuples = TestAggregateOutpoutCollector.emptyTupleSet
     expectedTuples.add((0, Map((2, BatchID(1)) -> ((timeStamp, 1)), (1, BatchID(1)) -> ((timeStamp, 1)), (3, BatchID(1)) -> ((timeStamp, 1)), (4, BatchID(1)) -> ((timeStamp, 1))), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)

--- a/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
+++ b/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
@@ -64,8 +64,8 @@ class TestKeyValueSpout extends WordSpec {
 
     //output
     val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
-    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 1), (2, BatchID(1)) -> (timeStamp, 1)), None, None))
-    expectedTuples.add((0, Map((3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1)), None, None))
+    expectedTuples.add((0, Map((1, BatchID(1)) -> ((timeStamp, 1)), (2, BatchID(1)) -> ((timeStamp, 1))), None, None))
+    expectedTuples.add((0, Map((3, BatchID(1)) -> ((timeStamp, 1)), (4, BatchID(1)) -> ((timeStamp, 1))), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -83,7 +83,7 @@ class TestKeyValueSpout extends WordSpec {
 
     //output
     val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
-    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 6)), None, None))
+    expectedTuples.add((0, Map((1, BatchID(1)) -> ((timeStamp, 6))), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -118,7 +118,7 @@ class TestKeyValueSpout extends WordSpec {
 
     //output
     val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
-    expectedTuples.add((0, Map((2, BatchID(1)) -> (timeStamp, 1), (1, BatchID(1)) -> (timeStamp, 1), (3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1)), None, None))
+    expectedTuples.add((0, Map((2, BatchID(1)) -> ((timeStamp, 1)), (1, BatchID(1)) -> ((timeStamp, 1)), (3, BatchID(1)) -> ((timeStamp, 1)), (4, BatchID(1)) -> ((timeStamp, 1))), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()

--- a/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
+++ b/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/TestKeyValueSpout.scala
@@ -1,26 +1,18 @@
 package com.twitter.summingbird.storm
 
-import backtype.storm.spout.{ ISpoutOutputCollector, SpoutOutputCollector }
-import com.twitter.summingbird.storm.spout.{ KeyValueSpout, TraversableSpout }
-import backtype.storm.task.TopologyContext
-import backtype.storm.topology.IRichSpout
+import backtype.storm.spout.ISpoutOutputCollector
 import backtype.storm.tuple.Values
 import com.twitter.algebird.Semigroup
-import com.twitter.algebird.util.summer.{ BufferSize, FlushFrequency, Incrementor, MemoryFlushPercent, SyncSummingQueue }
+import com.twitter.algebird.util.summer.{ AsyncSummer, BufferSize, FlushFrequency, MemoryFlushPercent, SyncSummingQueue }
 import com.twitter.summingbird.online.executor.KeyValueShards
 import com.twitter.summingbird.online.option.SummerBuilder
 import com.twitter.summingbird.storm.spout.KeyValueSpout
 import com.twitter.tormenta.spout.{ BaseSpout, Spout }
 import com.twitter.util.Duration
-import com.twitter.algebird.util.summer.SyncSummingQueue
 import com.twitter.summingbird.batch.{ BatchID, Timestamp }
 import com.twitter.summingbird.storm.collector.AggregatorOutputCollector
-import java.util
-import java.util.HashMap
-import org.junit.runner.RunWith
-import org.scalatest.{ FunSuite, WordSpec }
-import org.scalatest.junit.JUnitRunner
-import java.util.List
+import java.util.{ List => JList }
+import org.scalatest.WordSpec
 import org.scalacheck._
 import scala.collection.mutable.{ Set => MSet }
 
@@ -31,7 +23,7 @@ import scala.collection.mutable.{ Set => MSet }
 object TestKeyValueSpout {
   def getSyncSummingQueueBuildSummer(batchSize: Int, flushFrequency: Duration, memFlushPercent: Int) = {
     new SummerBuilder {
-      def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {
+      def getSummer[K, V: Semigroup]: AsyncSummer[(K, V), Map[K, V]] = {
         new SyncSummingQueue[K, V](
           BufferSize(batchSize),
           FlushFrequency(flushFrequency),
@@ -48,7 +40,7 @@ object TestKeyValueSpout {
 }
 class TestKeyValueSpout extends WordSpec {
 
-  def process(spout: Spout[(Timestamp, (Int, Int))], summer: SummerBuilder, expected: MSet[(Int, Map[_, _])]) = {
+  def process(spout: Spout[(Timestamp, (Int, Int))], summer: SummerBuilder, expected: MSet[(Int, Map[_, _], Option[String], Option[Any])]) = {
     val formattedSummerSpout = spout.map {
       case (time, (k, v)) => ((k, BatchID(1)), (time, v))
     }
@@ -71,9 +63,9 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _])]()
-    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 1), (2, BatchID(1)) -> (timeStamp, 1))))
-    expectedTuples.add((0, Map((3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1))))
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 1), (2, BatchID(1)) -> (timeStamp, 1)), None, None))
+    expectedTuples.add((0, Map((3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1)), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -90,8 +82,8 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _])]()
-    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 6))))
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map((1, BatchID(1)) -> (timeStamp, 6)), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -108,7 +100,7 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _])]()
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -125,8 +117,8 @@ class TestKeyValueSpout extends WordSpec {
     }
 
     //output
-    val expectedTuples = MSet[(Int, Map[_, _])]()
-    expectedTuples.add((0, Map((2, BatchID(1)) -> (timeStamp, 1), (1, BatchID(1)) -> (timeStamp, 1), (3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1))))
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map((2, BatchID(1)) -> (timeStamp, 1), (1, BatchID(1)) -> (timeStamp, 1), (3, BatchID(1)) -> (timeStamp, 1), (4, BatchID(1)) -> (timeStamp, 1)), None, None))
 
     val (spout, collector) = process(basespout, summer, expectedTuples)
     spout.nextTuple()
@@ -134,6 +126,7 @@ class TestKeyValueSpout extends WordSpec {
     spout.nextTuple()
     assert(collector.getSize == 0)
   }
+
 }
 
 class MockedISpoutOutputCollector extends ISpoutOutputCollector {
@@ -142,11 +135,11 @@ class MockedISpoutOutputCollector extends ISpoutOutputCollector {
   override def emitDirect(
     i: Int,
     s: String,
-    list: util.List[AnyRef],
+    list: JList[AnyRef],
     o: scala.Any): Unit = ???
 
   override def emit(
     s: String,
-    list: util.List[AnyRef],
-    o: scala.Any): util.List[Integer] = ???
+    list: JList[AnyRef],
+    o: scala.Any): JList[Integer] = ???
 }

--- a/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollectorTest.scala
+++ b/summingbird-storm/src/test/scala/com/twitter/summingbird/storm/collector/AggregatorOutputCollectorTest.scala
@@ -1,0 +1,74 @@
+package com.twitter.summingbird.storm.collector
+
+import backtype.storm.spout.ISpoutOutputCollector
+import backtype.storm.tuple.Values
+import com.twitter.algebird.Semigroup
+import com.twitter.algebird.util.summer.AsyncSummer
+import com.twitter.summingbird.online.executor.KeyValueShards
+import com.twitter.summingbird.online.option.SummerBuilder
+import com.twitter.summingbird.storm.{ Counter, MockedISpoutOutputCollector, TestAggregateOutpoutCollector }
+import com.twitter.util.Future
+import org.scalatest.WordSpec
+import scala.collection.mutable.{ Set => MSet }
+
+class TestAsyncSummer extends AsyncSummer[(Int, Int), Iterable[(Int, Int)]] {
+  override def flush: Future[Iterable[(Int, Int)]] = Future.Nil
+  override def isFlushed = true
+  override def tick = Future.Nil
+  override def addAll(vals: TraversableOnce[(Int, Int)]): Future[Iterable[(Int, Int)]] =
+    Future(Map(0 -> 10))
+}
+
+class AggregatorOutputCollectorTest extends WordSpec {
+  def setup(expected: MSet[(Int, Map[_, _], Option[String], Option[Any])]) = {
+    val mockCollector: ISpoutOutputCollector = new MockedISpoutOutputCollector
+    val validatingCollector = new TestAggregateOutpoutCollector(mockCollector, expected)
+
+    val summerBuilder = new SummerBuilder {
+      def getSummer[K, V: Semigroup]: AsyncSummer[(K, V), Map[K, V]] =
+        (new TestAsyncSummer).asInstanceOf[AsyncSummer[(K, V), Map[K, V]]]
+    }
+
+    val aggregatorCollector = new AggregatorOutputCollector(
+      validatingCollector,
+      summerBuilder,
+      KeyValueShards(10),
+      Counter("flush"),
+      Counter("execTime")
+    )(Semigroup.intSemigroup)
+
+    (aggregatorCollector, validatingCollector)
+  }
+
+  "Yields addAll result with no stream/message ID" in {
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map(0 -> 10), None, None))
+    val (aggregator, validator) = setup(expectedTuples)
+    aggregator.emit(new Values((4, 5).asInstanceOf[AnyRef]))
+    assert(validator.getSize == 0)
+  }
+
+  "Yields addAll result with the specified stream ID" in {
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map(0 -> 10), Some("foo"), None))
+    val (aggregator, validator) = setup(expectedTuples)
+    aggregator.emit("foo", new Values((4, 5).asInstanceOf[AnyRef]))
+    assert(validator.getSize == 0)
+  }
+
+  "Yields addAll result with the associated message ID" in {
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map(0 -> 10), None, Some(List("messageId"))))
+    val (aggregator, validator) = setup(expectedTuples)
+    aggregator.emit(new Values((0, 5).asInstanceOf[AnyRef]), "messageId")
+    assert(validator.getSize == 0)
+  }
+
+  "Doesn't return message ID from colliding key" in {
+    val expectedTuples = MSet[(Int, Map[_, _], Option[String], Option[Any])]()
+    expectedTuples.add((0, Map(0 -> 10), None, None))
+    val (aggregator, validator) = setup(expectedTuples)
+    aggregator.emit(new Values((10, 5).asInstanceOf[AnyRef]), "messageId")
+    assert(validator.getSize == 0)
+  }
+}


### PR DESCRIPTION
Fixes #692

Getting rid of `streamMessageIdTracker` because that's the wrong scope to track message IDs.  Pushing the message IDs instead into the `AsyncSummer`.

Reworking `TestAggregateOutpoutCollector` a bit to accept expected message IDs and stream names.  Existing tests just use `None` for these.

Adding new `AggregatorOutputCollectorTest`.  This is pretty simple, using an `AsyncSummer` that always returns the same thing from `addAll`, but is sufficient to illustrate the issue captured in #692.
