### PR TITLE
Get rid of `WireFmt` and `RuntimeContext` in `OperationContainer`

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -22,7 +22,7 @@ import com.twitter.util._
 
 import scala.util.Try
 
-abstract class AsyncBase[I, O, S, D](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S] {
+abstract class AsyncBase[I, O, S](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S] {
 
   /**
    * If you can use Future.value below, do so. The double Future is here to deal with

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -22,7 +22,7 @@ import com.twitter.util._
 
 import scala.util.Try
 
-abstract class AsyncBase[I, O, S, D, RC](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S, RC] {
+abstract class AsyncBase[I, O, S, D](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S] {
 
   /**
    * If you can use Future.value below, do so. The double Future is here to deal with

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -16,16 +16,13 @@ limitations under the License.
 
 package com.twitter.summingbird.online.executor
 
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.twitter.summingbird.online.FutureQueue
 import com.twitter.summingbird.online.option.{ MaxEmitPerExecute, MaxFutureWaitTime, MaxWaitingFutures }
 import com.twitter.util._
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
-abstract class AsyncBase[I, O, S, D, RC](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S, D, RC] {
+abstract class AsyncBase[I, O, S, D, RC](maxWaitingFutures: MaxWaitingFutures, maxWaitingTime: MaxFutureWaitTime, maxEmitPerExec: MaxEmitPerExecute) extends Serializable with OperationContainer[I, O, S, RC] {
 
   /**
    * If you can use Future.value below, do so. The double Future is here to deal with

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -50,14 +50,14 @@ private[summingbird] case class KeyValueShards(get: Int) {
     math.abs(k.hashCode % get)
 }
 
-class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D, RC](
+class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D](
   @transient flatMapOp: FlatMapOperation[Event, (Key, Value)],
   summerBuilder: SummerBuilder,
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
   summerShards: KeyValueShards)
-    extends AsyncBase[Event, (Int, CMap[Key, Value]), S, D, RC](maxWaitingFutures,
+    extends AsyncBase[Event, (Int, CMap[Key, Value]), S, D](maxWaitingFutures,
       maxWaitingTime,
       maxEmitPerExec) {
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -124,7 +124,7 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_]](
     tup: Event) =
     lockedOp.get.apply(tup).map { cache(state, _) }.flatten
 
-  override def cleanup {
+  override def cleanup(): Unit = {
     lockedOp.get.close
     sCache.cleanup
   }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -17,7 +17,6 @@ limitations under the License.
 package com.twitter.summingbird.online.executor
 
 import com.twitter.algebird.Semigroup
-import com.twitter.bijection.Injection
 import com.twitter.util.Future
 
 import com.twitter.summingbird.online.Externalizer
@@ -57,18 +56,13 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D, RC](
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
-  summerShards: KeyValueShards,
-  pDecoder: Injection[Event, D],
-  pEncoder: Injection[(Int, CMap[Key, Value]), D])
+  summerShards: KeyValueShards)
     extends AsyncBase[Event, (Int, CMap[Key, Value]), S, D, RC](maxWaitingFutures,
       maxWaitingTime,
       maxEmitPerExec) {
 
   type InS = S
   type OutputElement = (Int, CMap[Key, Value])
-
-  val encoder = pEncoder
-  val decoder = pDecoder
 
   val lockedOp = Externalizer(flatMapOp)
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -50,14 +50,14 @@ private[summingbird] case class KeyValueShards(get: Int) {
     math.abs(k.hashCode % get)
 }
 
-class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_], D](
+class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_]](
   @transient flatMapOp: FlatMapOperation[Event, (Key, Value)],
   summerBuilder: SummerBuilder,
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
   summerShards: KeyValueShards)
-    extends AsyncBase[Event, (Int, CMap[Key, Value]), S, D](maxWaitingFutures,
+    extends AsyncBase[Event, (Int, CMap[Key, Value]), S](maxWaitingFutures,
       maxWaitingTime,
       maxEmitPerExec) {
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -40,5 +40,5 @@ class IntermediateFlatMap[T, U, S](
       List((List(state), Future.value(res)))
     }
 
-  override def cleanup() { lockedOp.get.close }
+  override def cleanup(): Unit = lockedOp.get.close
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -18,7 +18,6 @@ package com.twitter.summingbird.online.executor
 
 import com.twitter.util.Future
 
-import com.twitter.bijection.Injection
 import com.twitter.summingbird.online.Externalizer
 import com.twitter.summingbird.online.FlatMapOperation
 import com.twitter.summingbird.online.option.{
@@ -31,12 +30,7 @@ class IntermediateFlatMap[T, U, S, D, RC](
     @transient flatMapOp: FlatMapOperation[T, U],
     maxWaitingFutures: MaxWaitingFutures,
     maxWaitingTime: MaxFutureWaitTime,
-    maxEmitPerExec: MaxEmitPerExecute,
-    pDecoder: Injection[T, D],
-    pEncoder: Injection[U, D]) extends AsyncBase[T, U, S, D, RC](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
-
-  val encoder = pEncoder
-  val decoder = pDecoder
+    maxEmitPerExec: MaxEmitPerExecute) extends AsyncBase[T, U, S, D, RC](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
 
   val lockedOp = Externalizer(flatMapOp)
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -26,11 +26,11 @@ import com.twitter.summingbird.online.option.{
   MaxEmitPerExecute
 }
 
-class IntermediateFlatMap[T, U, S, D](
+class IntermediateFlatMap[T, U, S](
     @transient flatMapOp: FlatMapOperation[T, U],
     maxWaitingFutures: MaxWaitingFutures,
     maxWaitingTime: MaxFutureWaitTime,
-    maxEmitPerExec: MaxEmitPerExecute) extends AsyncBase[T, U, S, D](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
+    maxEmitPerExec: MaxEmitPerExecute) extends AsyncBase[T, U, S](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
 
   val lockedOp = Externalizer(flatMapOp)
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -26,11 +26,11 @@ import com.twitter.summingbird.online.option.{
   MaxEmitPerExecute
 }
 
-class IntermediateFlatMap[T, U, S, D, RC](
+class IntermediateFlatMap[T, U, S, D](
     @transient flatMapOp: FlatMapOperation[T, U],
     maxWaitingFutures: MaxWaitingFutures,
     maxWaitingTime: MaxFutureWaitTime,
-    maxEmitPerExec: MaxEmitPerExecute) extends AsyncBase[T, U, S, D, RC](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
+    maxEmitPerExec: MaxEmitPerExecute) extends AsyncBase[T, U, S, D](maxWaitingFutures, maxWaitingTime, maxEmitPerExec) {
 
   val lockedOp = Externalizer(flatMapOp)
 
@@ -40,5 +40,5 @@ class IntermediateFlatMap[T, U, S, D, RC](
       List((List(state), Future.value(res)))
     }
 
-  override def cleanup { lockedOp.get.close }
+  override def cleanup() { lockedOp.get.close }
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -19,11 +19,11 @@ package com.twitter.summingbird.online.executor
 import scala.util.Try
 
 trait OperationContainer[Input, Output, State] {
-  def init() {}
-  def cleanup() {}
+  def init(): Unit = {}
+  def cleanup(): Unit = {}
 
   def executeTick: TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
     data: Input): TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
-  def notifyFailure(inputs: Seq[State], e: Throwable) {}
+  def notifyFailure(inputs: Seq[State], e: Throwable): Unit = {}
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -17,11 +17,8 @@ limitations under the License.
 package com.twitter.summingbird.online.executor
 
 import scala.util.Try
-import com.twitter.bijection.Injection
 
-trait OperationContainer[Input, Output, State, WireFmt, RuntimeContext] {
-  def decoder: Injection[Input, WireFmt]
-  def encoder: Injection[Output, WireFmt]
+trait OperationContainer[Input, Output, State, RuntimeContext] {
   def executeTick: TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
     data: Input): TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -18,11 +18,12 @@ package com.twitter.summingbird.online.executor
 
 import scala.util.Try
 
-trait OperationContainer[Input, Output, State, RuntimeContext] {
+trait OperationContainer[Input, Output, State] {
+  def init() {}
+  def cleanup() {}
+
   def executeTick: TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
     data: Input): TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
-  def init(ctx: RuntimeContext) {}
-  def cleanup {}
   def notifyFailure(inputs: Seq[State], e: Throwable) {}
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -18,13 +18,11 @@ package com.twitter.summingbird.online.executor
 
 import com.twitter.util.{ Await, Future, Promise }
 import com.twitter.algebird.util.summer.AsyncSummer
-import com.twitter.algebird.{ Semigroup, SummingQueue }
+import com.twitter.algebird.Semigroup
 import com.twitter.storehaus.algebra.Mergeable
-import com.twitter.bijection.Injection
 
-import com.twitter.summingbird.online.{ FlatMapOperation, Externalizer, MergeableStoreFactory }
+import com.twitter.summingbird.online.{ FlatMapOperation, Externalizer }
 import com.twitter.summingbird.online.option._
-import com.twitter.summingbird.option.CacheSize
 
 // These CMaps we generate in the FFM, we use it as an immutable wrapper around
 // a mutable map.
@@ -63,16 +61,12 @@ class Summer[Key, Value: Semigroup, Event, S, D, RC](
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
-  includeSuccessHandler: IncludeSuccessHandler,
-  pDecoder: Injection[(Int, CMap[Key, Value]), D],
-  pEncoder: Injection[Event, D]) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S], D, RC](
+  includeSuccessHandler: IncludeSuccessHandler) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S], D, RC](
   maxWaitingFutures,
   maxWaitingTime,
   maxEmitPerExec) {
 
   val lockedOp = Externalizer(flatMapOp)
-  val encoder = pEncoder
-  val decoder = pDecoder
 
   val storeBox = Externalizer(storeSupplier)
   lazy val storePromise = Promise[Mergeable[Key, Value]]

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -52,7 +52,7 @@ import scala.util.control.NonFatal
  * @author Ashu Singhal
  */
 
-class Summer[Key, Value: Semigroup, Event, S, D](
+class Summer[Key, Value: Semigroup, Event, S](
   @transient storeSupplier: () => Mergeable[Key, Value],
   @transient flatMapOp: FlatMapOperation[(Key, (Option[Value], Value)), Event],
   @transient successHandler: OnlineSuccessHandler,
@@ -61,7 +61,7 @@ class Summer[Key, Value: Semigroup, Event, S, D](
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
-  includeSuccessHandler: IncludeSuccessHandler) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S], D](
+  includeSuccessHandler: IncludeSuccessHandler) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S]](
   maxWaitingFutures,
   maxWaitingTime,
   maxEmitPerExec) {

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -78,7 +78,7 @@ class Summer[Key, Value: Semigroup, Event, S](
   val successHandlerBox = Externalizer(successHandler)
   var successHandlerOpt: Option[OnlineSuccessHandler] = null
 
-  override def init() {
+  override def init(): Unit = {
     super.init()
     storePromise.setValue(storeBox.get())
     store.toString // Do the lazy evaluation now so we can connect before tuples arrive.
@@ -119,5 +119,5 @@ class Summer[Key, Value: Semigroup, Event, S](
     }
   }
 
-  override def cleanup = Await.result(store.close)
+  override def cleanup(): Unit = Await.result(store.close)
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -52,7 +52,7 @@ import scala.util.control.NonFatal
  * @author Ashu Singhal
  */
 
-class Summer[Key, Value: Semigroup, Event, S, D, RC](
+class Summer[Key, Value: Semigroup, Event, S, D](
   @transient storeSupplier: () => Mergeable[Key, Value],
   @transient flatMapOp: FlatMapOperation[(Key, (Option[Value], Value)), Event],
   @transient successHandler: OnlineSuccessHandler,
@@ -61,7 +61,7 @@ class Summer[Key, Value: Semigroup, Event, S, D, RC](
   maxWaitingFutures: MaxWaitingFutures,
   maxWaitingTime: MaxFutureWaitTime,
   maxEmitPerExec: MaxEmitPerExecute,
-  includeSuccessHandler: IncludeSuccessHandler) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S], D, RC](
+  includeSuccessHandler: IncludeSuccessHandler) extends AsyncBase[(Int, CMap[Key, Value]), Event, InputState[S], D](
   maxWaitingFutures,
   maxWaitingTime,
   maxEmitPerExec) {
@@ -78,8 +78,8 @@ class Summer[Key, Value: Semigroup, Event, S, D, RC](
   val successHandlerBox = Externalizer(successHandler)
   var successHandlerOpt: Option[OnlineSuccessHandler] = null
 
-  override def init(runtimeContext: RC) {
-    super.init(runtimeContext)
+  override def init() {
+    super.init()
     storePromise.setValue(storeBox.get())
     store.toString // Do the lazy evaluation now so we can connect before tuples arrive.
 

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
@@ -16,9 +16,6 @@
 
 package com.twitter.summingbird.online.executor
 
-import java.util.concurrent.CyclicBarrier
-
-import com.twitter.bijection.Injection
 import com.twitter.conversions.time._
 import com.twitter.summingbird.online.FutureQueue
 import com.twitter.summingbird.online.option.{ MaxEmitPerExecute, MaxFutureWaitTime, MaxWaitingFutures }
@@ -72,8 +69,6 @@ class AsyncBaseSpec extends WordSpec {
     override lazy val futureQueue = queue
     override def apply(state: Int, in: Int) = applyData
     override def tick = tickData
-    override def decoder: Injection[Int, Int] = implicitly
-    override def encoder: Injection[Int, Int] = implicitly
   }
 
   def promise = Promise[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]]

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
@@ -61,7 +61,7 @@ class AsyncBaseSpec extends WordSpec {
   class TestAsyncBase(
     queue: TestFutureQueue,
     tickData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented"),
-    applyData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented")) extends AsyncBase[Int, Int, Int, Int, Unit](
+    applyData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented")) extends AsyncBase[Int, Int, Int, Int](
     MaxWaitingFutures(100),
     MaxFutureWaitTime(1.minute),
     MaxEmitPerExecute(57)

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
@@ -61,7 +61,7 @@ class AsyncBaseSpec extends WordSpec {
   class TestAsyncBase(
     queue: TestFutureQueue,
     tickData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented"),
-    applyData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented")) extends AsyncBase[Int, Int, Int, Int](
+    applyData: => Future[TraversableOnce[(Seq[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented")) extends AsyncBase[Int, Int, Int](
     MaxWaitingFutures(100),
     MaxFutureWaitTime(1.minute),
     MaxEmitPerExecute(57)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -49,7 +49,7 @@ case class BaseBolt[I, O](jobID: JobId,
     maxExecutePerSec: MaxExecutePerSecond,
     decoder: Injection[I,  JList[AnyRef]],
     encoder: Injection[O,  JList[AnyRef]],
-    executor: OperationContainer[I, O, InputState[Tuple], TopologyContext]) extends IRichBolt {
+    executor: OperationContainer[I, O, InputState[Tuple]]) extends IRichBolt {
 
   @transient protected lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -173,7 +173,7 @@ case class BaseBolt[I, O](jobID: JobId,
   override def prepare(conf: JMap[_, _], context: TopologyContext, oc: OutputCollector) {
     collector = oc
     metrics().foreach { _.register(context) }
-    executor.init(context)
+    executor.init()
     StormStatProvider.registerMetrics(jobID, context, countersForBolt)
     SummingbirdRuntimeStats.addPlatformStatProvider(StormStatProvider)
     logger.debug("In Bolt prepare: added jobID stat provider for jobID {}", jobID)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -16,25 +16,22 @@ limitations under the License.
 
 package com.twitter.summingbird.storm
 
-import scala.util.{ Success, Failure }
-
-import backtype.storm.task.{ OutputCollector, TopologyContext }
+import scala.util.{Failure, Success}
+import backtype.storm.task.{OutputCollector, TopologyContext}
 import backtype.storm.topology.IRichBolt
 import backtype.storm.topology.OutputFieldsDeclarer
-import backtype.storm.tuple.{ Tuple, TupleImpl, Fields }
-
-import java.util.{ Map => JMap }
-import com.twitter.summingbird.storm.option.{ AckOnEntry, AnchorTuples, MaxExecutePerSecond }
+import backtype.storm.tuple.{Fields, Tuple, TupleImpl}
+import com.twitter.bijection.Injection
+import java.util.{Map => JMap}
+import com.twitter.summingbird.storm.option.{AckOnEntry, AnchorTuples, MaxExecutePerSecond}
 import com.twitter.summingbird.online.executor.OperationContainer
-import com.twitter.summingbird.online.executor.{ InflightTuples, InputState }
+import com.twitter.summingbird.online.executor.InputState
 import com.twitter.summingbird.option.JobId
-import com.twitter.summingbird.{ Group, JobCounters, Name, SummingbirdRuntimeStats }
+import com.twitter.summingbird.{Group, JobCounters, Name, SummingbirdRuntimeStats}
 import com.twitter.summingbird.online.Externalizer
-
 import scala.collection.JavaConverters._
-
-import java.util.{ List => JList }
-import org.slf4j.{ LoggerFactory, Logger }
+import java.util.{List => JList}
+import org.slf4j.{Logger, LoggerFactory}
 
 /**
  *
@@ -50,7 +47,9 @@ case class BaseBolt[I, O](jobID: JobId,
     outputFields: Fields,
     ackOnEntry: AckOnEntry,
     maxExecutePerSec: MaxExecutePerSecond,
-    executor: OperationContainer[I, O, InputState[Tuple], JList[AnyRef], TopologyContext]) extends IRichBolt {
+    decoder: Injection[I,  JList[AnyRef]],
+    encoder: Injection[O,  JList[AnyRef]],
+    executor: OperationContainer[I, O, InputState[Tuple], TopologyContext]) extends IRichBolt {
 
   @transient protected lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
@@ -131,7 +130,7 @@ case class BaseBolt[I, O](jobID: JobId,
      * System ticks come with a fixed stream id
      */
     val curResults = if (!tuple.getSourceStreamId.equals("__tick")) {
-      val tsIn = executor.decoder.invert(tuple.getValues).get // Failing to decode here is an ERROR
+      val tsIn = decoder.invert(tuple.getValues).get // Failing to decode here is an ERROR
       // Don't hold on to the input values
       clearValues(tuple)
       if (earlyAck) { collector.ack(tuple) }
@@ -155,12 +154,12 @@ case class BaseBolt[I, O](jobID: JobId,
     if (hasDependants) {
       if (anchorTuples.anchor) {
         results.foreach { result =>
-          collector.emit(inputs.map(_.state).asJava, executor.encoder(result))
+          collector.emit(inputs.map(_.state).asJava, encoder(result))
           emitCount += 1
         }
       } else { // don't anchor
         results.foreach { result =>
-          collector.emit(executor.encoder(result))
+          collector.emit(encoder(result))
           emitCount += 1
         }
       }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -16,22 +16,22 @@ limitations under the License.
 
 package com.twitter.summingbird.storm
 
-import scala.util.{Failure, Success}
-import backtype.storm.task.{OutputCollector, TopologyContext}
+import scala.util.{ Failure, Success }
+import backtype.storm.task.{ OutputCollector, TopologyContext }
 import backtype.storm.topology.IRichBolt
 import backtype.storm.topology.OutputFieldsDeclarer
-import backtype.storm.tuple.{Fields, Tuple, TupleImpl}
+import backtype.storm.tuple.{ Fields, Tuple, TupleImpl }
 import com.twitter.bijection.Injection
-import java.util.{Map => JMap}
-import com.twitter.summingbird.storm.option.{AckOnEntry, AnchorTuples, MaxExecutePerSecond}
+import java.util.{ Map => JMap }
+import com.twitter.summingbird.storm.option.{ AckOnEntry, AnchorTuples, MaxExecutePerSecond }
 import com.twitter.summingbird.online.executor.OperationContainer
 import com.twitter.summingbird.online.executor.InputState
 import com.twitter.summingbird.option.JobId
-import com.twitter.summingbird.{Group, JobCounters, Name, SummingbirdRuntimeStats}
+import com.twitter.summingbird.{ Group, JobCounters, Name, SummingbirdRuntimeStats }
 import com.twitter.summingbird.online.Externalizer
 import scala.collection.JavaConverters._
-import java.util.{List => JList}
-import org.slf4j.{Logger, LoggerFactory}
+import java.util.{ List => JList }
+import org.slf4j.{ Logger, LoggerFactory }
 
 /**
  *
@@ -47,8 +47,8 @@ case class BaseBolt[I, O](jobID: JobId,
     outputFields: Fields,
     ackOnEntry: AckOnEntry,
     maxExecutePerSec: MaxExecutePerSecond,
-    decoder: Injection[I,  JList[AnyRef]],
-    encoder: Injection[O,  JList[AnyRef]],
+    decoder: Injection[I, JList[AnyRef]],
+    encoder: Injection[O, JList[AnyRef]],
     executor: OperationContainer[I, O, InputState[Tuple]]) extends IRichBolt {
 
   @transient protected lazy val logger: Logger = LoggerFactory.getLogger(getClass)


### PR DESCRIPTION
In this PR I removed `WireFmt` and `RuntimeContext` type parameters from `OperationContainer`. 

Main reason to do that was to make `OperationContainer` composable and responsible only for how to do computations on inputs. Therefore `WireFmt` moved to places which wraps `OperationContainer` in Storm.

`RuntimeContext` wasn't really used anywhere and I removed it for simplicity. 
