### PR TITLE
Track state in summingbird-online as an Iterator rather than a Seq.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,11 @@ val ignoredABIProblems = {
     exclude[IncompatibleMethTypeProblem]("com.twitter.summingbird.storm.Storm.get"),
     exclude[IncompatibleMethTypeProblem]("com.twitter.summingbird.storm.Storm.getOrElse"),
     exclude[DirectMissingMethodProblem]("com.twitter.summingbird.storm.BaseBolt.apply"),
-    exclude[IncompatibleResultTypeProblem]("com.twitter.summingbird.example.Memcache.client")
+    exclude[IncompatibleResultTypeProblem]("com.twitter.summingbird.example.Memcache.client"),
+    exclude[DirectMissingMethodProblem]("com.twitter.summingbird.online.executor.OperationContainer.notifyFailure"),
+    exclude[ReversedMissingMethodProblem]("com.twitter.summingbird.online.executor.OperationContainer.notifyFailure"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.summingbird.online.executor.AsyncBase.notifyFailure"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.summingbird.online.executor.Summer.notifyFailure")
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ val storehausVersion = "0.15.0-RC1"
 val stormDep = "storm" % "storm" % "0.9.0-wip15" //This project also compiles with the latest storm, which is in fact required to run the example
 val tormentaVersion = "0.11.1"
 val utilVersion = "6.34.0"
+val chainVersion = "0.1.0"
 
 val extraSettings = mimaDefaultSettings ++ scalariformSettings
 
@@ -293,7 +294,8 @@ lazy val summingbirdOnline = module("online").settings(
     "com.twitter" %% "chill" % chillVersion,
     "com.twitter" %% "storehaus-algebra" % storehausVersion,
     "com.twitter" %% "util-core" % utilVersion,
-    "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
+    "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test",
+    "org.spire-math" %% "chain" % chainVersion
   )
 ).dependsOn(
   summingbirdCore % "test->test;compile->compile",
@@ -315,6 +317,7 @@ lazy val summingbirdStorm = module("storm").settings(
     "com.twitter" %% "scalding-args" % scaldingVersion,
     "com.twitter" %% "tormenta-core" % tormentaVersion,
     "com.twitter" %% "util-core" % utilVersion,
+    "org.spire-math" %% "chain" % chainVersion,
     stormDep % "provided"
   )
 ).dependsOn(

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/AsyncBase.scala
@@ -32,7 +32,7 @@ abstract class AsyncBase[I, O, S](maxWaitingFutures: MaxWaitingFutures, maxWaiti
   def apply(state: S, in: I): Future[TraversableOnce[(Stream[S], Future[TraversableOnce[O]])]]
   def tick: Future[TraversableOnce[(Stream[S], Future[TraversableOnce[O]])]] = Future.value(Nil)
 
-  implicit def itertorSemigroup[T]: Semigroup[Stream[T]] = new Semigroup[Stream[T]] {
+  implicit def streamSemigroup[T]: Semigroup[Stream[T]] = new Semigroup[Stream[T]] {
     override def plus(l: Stream[T], r: Stream[T]): Stream[T] = l ++ r
   }
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/FinalFlatMap.scala
@@ -29,6 +29,7 @@ import com.twitter.summingbird.online.option.{
   MaxFutureWaitTime,
   MaxEmitPerExecute
 }
+import chain.Chain
 import scala.collection.mutable.{ Map => MMap, ListBuffer }
 // These CMaps we generate in the FFM, we use it as an immutable wrapper around
 // a mutable map.
@@ -67,16 +68,16 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_]](
   val lockedOp = Externalizer(flatMapOp)
 
   type SummerK = Key
-  type SummerV = (Stream[S], Value)
+  type SummerV = (Chain[S], Value)
 
-  lazy val sCache = summerBuilder.getSummer[SummerK, SummerV](implicitly[Semigroup[(Stream[S], Value)]])
+  lazy val sCache = summerBuilder.getSummer[SummerK, SummerV](implicitly[Semigroup[(Chain[S], Value)]])
 
   // Lazy transient as const futures are not serializable
   @transient private[this] lazy val noData = List(
-    (List().toStream, Future.value(Nil))
+    (Chain.empty, Future.value(Nil))
   )
 
-  private def formatResult(outData: Map[Key, (Stream[S], Value)]): TraversableOnce[(Stream[S], Future[TraversableOnce[OutputElement]])] = {
+  private def formatResult(outData: Map[Key, (Chain[S], Value)]): TraversableOnce[(Chain[S], Future[TraversableOnce[OutputElement]])] = {
     if (outData.isEmpty) {
       noData
     } else {
@@ -86,34 +87,34 @@ class FinalFlatMap[Event, Key, Value: Semigroup, S <: InputState[_]](
         case (k, (listS, v)) =>
           val newK = summerShards.summerIdFor(k)
           val (buffer, mmap) = mmMap.getOrElseUpdate(newK, (ListBuffer[S](), MMap[Key, Value]()))
-          buffer ++= listS
+          buffer ++= listS.iterator
           mmap += k -> v
       }
 
       mmMap.toIterator.map {
         case (outerKey, (listS, innerMap)) =>
-          (listS.toStream, Future.value(List((outerKey, innerMap))))
+          (Chain(listS), Future.value(List((outerKey, innerMap))))
       }
     }
   }
 
-  override def tick: Future[TraversableOnce[(Stream[S], Future[TraversableOnce[OutputElement]])]] =
+  override def tick: Future[TraversableOnce[(Chain[S], Future[TraversableOnce[OutputElement]])]] =
     sCache.tick.map(formatResult(_))
 
   def cache(state: S,
-    items: TraversableOnce[(Key, Value)]): Future[TraversableOnce[(Stream[S], Future[TraversableOnce[OutputElement]])]] =
+    items: TraversableOnce[(Key, Value)]): Future[TraversableOnce[(Chain[S], Future[TraversableOnce[OutputElement]])]] =
     try {
       val itemL = items.toList
       if (itemL.size > 0) {
         state.fanOut(itemL.size)
         sCache.addAll(itemL.map {
           case (k, v) =>
-            k -> (Stream(state), v)
+            k -> (Chain.single(state), v)
         }).map(formatResult(_))
       } else { // Here we handle mapping to nothing, option map et. al
         Future.value(
           List(
-            (Stream(state), Future.value(Nil))
+            (Chain.single(state), Future.value(Nil))
           )
         )
       }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -35,9 +35,9 @@ class IntermediateFlatMap[T, U, S](
   val lockedOp = Externalizer(flatMapOp)
 
   override def apply(state: S,
-    tup: T): Future[Iterable[(Iterator[S], Future[TraversableOnce[U]])]] =
+    tup: T): Future[Iterable[(Stream[S], Future[TraversableOnce[U]])]] =
     lockedOp.get.apply(tup).map { res =>
-      List((Iterator.single(state), Future.value(res)))
+      List((Stream(state), Future.value(res)))
     }
 
   override def cleanup(): Unit = lockedOp.get.close

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -25,6 +25,7 @@ import com.twitter.summingbird.online.option.{
   MaxFutureWaitTime,
   MaxEmitPerExecute
 }
+import chain.Chain
 
 class IntermediateFlatMap[T, U, S](
     @transient flatMapOp: FlatMapOperation[T, U],
@@ -35,9 +36,9 @@ class IntermediateFlatMap[T, U, S](
   val lockedOp = Externalizer(flatMapOp)
 
   override def apply(state: S,
-    tup: T): Future[Iterable[(Stream[S], Future[TraversableOnce[U]])]] =
+    tup: T): Future[Iterable[(Chain[S], Future[TraversableOnce[U]])]] =
     lockedOp.get.apply(tup).map { res =>
-      List((Stream(state), Future.value(res)))
+      List((Chain.single(state), Future.value(res)))
     }
 
   override def cleanup(): Unit = lockedOp.get.close

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/IntermediateFlatMap.scala
@@ -35,9 +35,9 @@ class IntermediateFlatMap[T, U, S](
   val lockedOp = Externalizer(flatMapOp)
 
   override def apply(state: S,
-    tup: T): Future[Iterable[(List[S], Future[TraversableOnce[U]])]] =
+    tup: T): Future[Iterable[(Iterator[S], Future[TraversableOnce[U]])]] =
     lockedOp.get.apply(tup).map { res =>
-      List((List(state), Future.value(res)))
+      List((Iterator.single(state), Future.value(res)))
     }
 
   override def cleanup(): Unit = lockedOp.get.close

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -22,8 +22,8 @@ trait OperationContainer[Input, Output, State] {
   def init(): Unit = {}
   def cleanup(): Unit = {}
 
-  def executeTick: TraversableOnce[(Iterator[State], Try[TraversableOnce[Output]])]
+  def executeTick: TraversableOnce[(Stream[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
-    data: Input): TraversableOnce[(Iterator[State], Try[TraversableOnce[Output]])]
-  def notifyFailure(inputs: Iterator[State], e: Throwable): Unit = {}
+    data: Input): TraversableOnce[(Stream[State], Try[TraversableOnce[Output]])]
+  def notifyFailure(inputs: Stream[State], e: Throwable): Unit = {}
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -22,8 +22,8 @@ trait OperationContainer[Input, Output, State] {
   def init(): Unit = {}
   def cleanup(): Unit = {}
 
-  def executeTick: TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
+  def executeTick: TraversableOnce[(Iterator[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
-    data: Input): TraversableOnce[(Seq[State], Try[TraversableOnce[Output]])]
-  def notifyFailure(inputs: Seq[State], e: Throwable): Unit = {}
+    data: Input): TraversableOnce[(Iterator[State], Try[TraversableOnce[Output]])]
+  def notifyFailure(inputs: Iterator[State], e: Throwable): Unit = {}
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/OperationContainer.scala
@@ -16,14 +16,15 @@ limitations under the License.
 
 package com.twitter.summingbird.online.executor
 
+import chain.Chain
 import scala.util.Try
 
 trait OperationContainer[Input, Output, State] {
   def init(): Unit = {}
   def cleanup(): Unit = {}
 
-  def executeTick: TraversableOnce[(Stream[State], Try[TraversableOnce[Output]])]
+  def executeTick: TraversableOnce[(Chain[State], Try[TraversableOnce[Output]])]
   def execute(state: State,
-    data: Input): TraversableOnce[(Stream[State], Try[TraversableOnce[Output]])]
-  def notifyFailure(inputs: Stream[State], e: Throwable): Unit = {}
+    data: Input): TraversableOnce[(Chain[State], Try[TraversableOnce[Output]])]
+  def notifyFailure(inputs: Chain[State], e: Throwable): Unit = {}
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/executor/Summer.scala
@@ -24,6 +24,8 @@ import com.twitter.storehaus.algebra.Mergeable
 import com.twitter.summingbird.online.{ FlatMapOperation, Externalizer }
 import com.twitter.summingbird.online.option._
 
+import chain.Chain
+
 // These CMaps we generate in the FFM, we use it as an immutable wrapper around
 // a mutable map.
 import scala.collection.{ Map => CMap }
@@ -72,8 +74,8 @@ class Summer[Key, Value: Semigroup, Event, S](
   lazy val storePromise = Promise[Mergeable[Key, Value]]
   lazy val store = Await.result(storePromise)
 
-  lazy val sSummer: AsyncSummer[(Key, (Stream[InputState[S]], Value)), Map[Key, (Stream[InputState[S]], Value)]] =
-    summerBuilder.getSummer[Key, (Stream[InputState[S]], Value)](implicitly[Semigroup[(Stream[InputState[S]], Value)]])
+  lazy val sSummer: AsyncSummer[(Key, (Chain[InputState[S]], Value)), Map[Key, (Chain[InputState[S]], Value)]] =
+    summerBuilder.getSummer[Key, (Chain[InputState[S]], Value)](implicitly[Semigroup[(Chain[InputState[S]], Value)]])
 
   val exceptionHandlerBox = Externalizer(exceptionHandler.handlerFn.lift)
   val successHandlerBox = Externalizer(successHandler)
@@ -87,12 +89,12 @@ class Summer[Key, Value: Semigroup, Event, S](
     successHandlerOpt = if (includeSuccessHandler.get) Some(successHandlerBox.get) else None
   }
 
-  override def notifyFailure(inputs: Stream[InputState[S]], error: Throwable): Unit = {
+  override def notifyFailure(inputs: Chain[InputState[S]], error: Throwable): Unit = {
     super.notifyFailure(inputs, error)
     exceptionHandlerBox.get.apply(error)
   }
 
-  private def handleResult(kvs: Map[Key, (Stream[InputState[S]], Value)]): TraversableOnce[(Stream[InputState[S]], Future[TraversableOnce[Event]])] =
+  private def handleResult(kvs: Map[Key, (Chain[InputState[S]], Value)]): TraversableOnce[(Chain[InputState[S]], Future[TraversableOnce[Event]])] =
     store.multiMerge(kvs.mapValues(_._2)).iterator.map {
       case (k, beforeF) =>
         val (tups, delta) = kvs(k)
@@ -111,7 +113,7 @@ class Summer[Key, Value: Semigroup, Event, S](
       state.fanOut(innerTuples.size)
       val cacheEntries = innerTuples.map {
         case (k, v) =>
-          (k, (Stream(state), v))
+          (k, (Chain.single(state), v))
       }
 
       sSummer.addAll(cacheEntries).map(handleResult(_))

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -118,7 +118,7 @@ case class BaseBolt[I, O](jobID: JobId,
     logger.error(message, err)
   }
 
-  private def fail(inputs: Seq[InputState[Tuple]], error: Throwable): Unit = {
+  private def fail(inputs: Iterator[InputState[Tuple]], error: Throwable): Unit = {
     executor.notifyFailure(inputs, error)
     if (!earlyAck) { inputs.foreach(_.fail(collector.fail(_))) }
     logError("Storm DAG of: %d tuples failed".format(inputs.size), error)
@@ -149,12 +149,12 @@ case class BaseBolt[I, O](jobID: JobId,
     }
   }
 
-  private def finish(inputs: Seq[InputState[Tuple]], results: TraversableOnce[O]) {
+  private def finish(inputs: Iterator[InputState[Tuple]], results: TraversableOnce[O]) {
     var emitCount = 0
     if (hasDependants) {
       if (anchorTuples.anchor) {
         results.foreach { result =>
-          collector.emit(inputs.map(_.state).asJava, encoder(result))
+          collector.emit(inputs.map(_.state).toList.asJava, encoder(result))
           emitCount += 1
         }
       } else { // don't anchor

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BaseBolt.scala
@@ -118,7 +118,7 @@ case class BaseBolt[I, O](jobID: JobId,
     logger.error(message, err)
   }
 
-  private def fail(inputs: Iterator[InputState[Tuple]], error: Throwable): Unit = {
+  private def fail(inputs: Stream[InputState[Tuple]], error: Throwable): Unit = {
     executor.notifyFailure(inputs, error)
     if (!earlyAck) { inputs.foreach(_.fail(collector.fail(_))) }
     logError("Storm DAG of: %d tuples failed".format(inputs.size), error)
@@ -149,7 +149,7 @@ case class BaseBolt[I, O](jobID: JobId,
     }
   }
 
-  private def finish(inputs: Iterator[InputState[Tuple]], results: TraversableOnce[O]) {
+  private def finish(inputs: Stream[InputState[Tuple]], results: TraversableOnce[O]) {
     var emitCount = 0
     if (hasDependants) {
       if (anchorTuples.anchor) {


### PR DESCRIPTION
Fix for #689 . This should avoid n^2 compute complexity when summing single element lists of Storm tuples. 