### PR TITLE
Fix logging in storm tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -334,7 +334,14 @@ lazy val summingbirdStormTest = module("storm-test").settings(
     "com.twitter" %% "storehaus-algebra" % storehausVersion,
     "com.twitter" %% "tormenta-core" % tormentaVersion,
     "com.twitter" %% "util-core" % utilVersion,
-    stormDep % "provided"
+    stormDep % "provided",
+
+    // Storm uses log4j2 for logs, we want to enforce usage of log4j12,
+    // to make it consistent with other tests.
+    (stormDep
+      exclude("org.slf4j", "log4j-over-slf4j")
+      exclude("org.apache.logging.log4j", "log4j-slf4j-impl")) % "test",
+    "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
   )
 ).dependsOn(
   summingbirdCore % "test->test;compile->compile",
@@ -404,13 +411,10 @@ lazy val summingbirdBuilder = module("builder").settings(
 
 lazy val summingbirdExample = module("example").settings(
   libraryDependencies ++= Seq(
-    "log4j" % "log4j" % log4jVersion,
-    "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
-    stormDep exclude("org.slf4j", "log4j-over-slf4j") exclude("ch.qos.logback", "logback-classic"),
     "com.twitter" %% "bijection-netty" % bijectionVersion,
     "com.twitter" %% "tormenta-twitter" % tormentaVersion,
     "com.twitter" %% "storehaus-memcache" % storehausVersion,
-    "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
+    stormDep
   )
 ).dependsOn(summingbirdCore, summingbirdStorm)
 

--- a/project/travis-log4j.properties
+++ b/project/travis-log4j.properties
@@ -2,12 +2,12 @@ log4j.rootCategory=WARN, console
 log4j.rootLogger = WARN, console
 log4j.threshhold=ALL
 
-log4j.category.backtype.storm=ERROR
+log4j.category.org.apache.storm=ERROR
 log4j.category.com.twitter=INFO
 log4j.category.com.netflix=ERROR
 log4j.category.org.apache.zookeeper=ERROR
 
-log4j.logger.backtype.storm=ERROR
+log4j.logger.org.apache.storm=ERROR
 log4j.logger.com.twitter=INFO
 log4j.logger.com.netflix=ERROR
 log4j.logger.org.apache.zookeeper=ERROR


### PR DESCRIPTION
During upgrade to Storm 1.0.x API (https://github.com/twitter/summingbird/pull/699) we broke log levels in our storm tests. There are two reasons for that:
- We didn't change package names in log4j rules for travis we use
- Storm 1.0.x implements logging through `log4j2`, and therefore we need to exclude `log4j-over-slf4j` and `log4j-slf4j-impl` ( which is kinda `slf4j-over-log4j2`) from our tests classpath. 

This PR fix both issues.