### PR TITLE
Shrink jvm memory properties and use java 8

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -2,8 +2,8 @@
 -Xms1G
 -Xmx3G
 -Xss2m
--XX:MaxPermSize=512M
--XX:ReservedCodeCacheSize=250M
+-XX:MaxMetaspaceSize=384M
+-XX:ReservedCodeCacheSize=128M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 # effectively adds GC to Perm space

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ env:
 matrix:
   include:
     - scala: 2.10.6
+      jdk: oraclejdk8
       script: ./sbt -Dlog4j.configuration=$LOG4J ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
 
     - scala: 2.11.8
+      jdk: oraclejdk8
       script: ./sbt -Dlog4j.configuration=$LOG4J ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
       after_success:
         - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
I've limited metaspace size and shrinked code cache size to make tests memory behaviour more reliable.