### PR TITLE
Introduce StormTopologyBuilder

### DIFF
--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
@@ -21,7 +21,6 @@ import com.twitter.algebird.util.summer._
 import com.twitter.summingbird.{ Counter, Group, Name }
 import com.twitter.summingbird.online.option.{ CompactValues, SummerBuilder, SummerConstructor }
 import com.twitter.summingbird.option.JobId
-import com.twitter.summingbird.planner.Dag
 import com.twitter.summingbird.storm.planner.StormNode
 import com.twitter.util.{ Future, FuturePool }
 import java.util.concurrent.{ Executors, TimeUnit }
@@ -36,31 +35,32 @@ import Constants._
 object BuildSummer {
   @transient private val logger = LoggerFactory.getLogger(BuildSummer.getClass)
 
-  def apply(storm: Storm, dag: Dag[Storm], node: StormNode, jobID: JobId) = {
-    val opSummerConstructor = storm.get[SummerConstructor](dag, node).map(_._2)
-    logger.debug(s"Node (${dag.getNodeName(node)}): Queried for SummerConstructor, got $opSummerConstructor")
+  def apply(builder: StormTopologyBuilder, node: StormNode) = {
+    val opSummerConstructor = builder.get[SummerConstructor](node).map(_._2)
+    logger.debug(s"Node (${builder.getNodeName(node)}): Queried for SummerConstructor, got $opSummerConstructor")
 
     opSummerConstructor match {
       case Some(cons) =>
-        logger.debug(s"Node (${dag.getNodeName(node)}): Using user supplied SummerConstructor: $cons")
+        logger.debug(s"Node (${builder.getNodeName(node)}): Using user supplied SummerConstructor: $cons")
         cons.get
-      case None => legacyBuilder(storm, dag, node, jobID)
+      case None => legacyBuilder(builder, node)
     }
   }
 
-  private[this] final def legacyBuilder(storm: Storm, dag: Dag[Storm], node: StormNode, jobID: JobId) = {
-    val nodeName = dag.getNodeName(node)
-    val cacheSize = storm.getOrElse(dag, node, DEFAULT_FM_CACHE)
-    require(jobID.get != null, "Unable to register metrics with no job id present in the config updater")
+  private[this] final def legacyBuilder(builder: StormTopologyBuilder, node: StormNode) = {
+    val nodeName = builder.getNodeName(node)
+    val cacheSize = builder.getOrElse(node, DEFAULT_FM_CACHE)
+    val jobId = builder.jobId
+    require(jobId.get != null, "Unable to register metrics with no job id present in the config updater")
     logger.info(s"[$nodeName] cacheSize lowerbound: ${cacheSize.lowerBound}")
 
-    val memoryCounter = counter(jobID, Group(nodeName), Name("memory"))
-    val timeoutCounter = counter(jobID, Group(nodeName), Name("timeout"))
-    val sizeCounter = counter(jobID, Group(nodeName), Name("size"))
-    val tupleInCounter = counter(jobID, Group(nodeName), Name("tuplesIn"))
-    val tupleOutCounter = counter(jobID, Group(nodeName), Name("tuplesOut"))
-    val insertCounter = counter(jobID, Group(nodeName), Name("inserts"))
-    val insertFailCounter = counter(jobID, Group(nodeName), Name("insertFail"))
+    val memoryCounter = counter(jobId, Group(nodeName), Name("memory"))
+    val timeoutCounter = counter(jobId, Group(nodeName), Name("timeout"))
+    val sizeCounter = counter(jobId, Group(nodeName), Name("size"))
+    val tupleInCounter = counter(jobId, Group(nodeName), Name("tuplesIn"))
+    val tupleOutCounter = counter(jobId, Group(nodeName), Name("tuplesOut"))
+    val insertCounter = counter(jobId, Group(nodeName), Name("inserts"))
+    val insertFailCounter = counter(jobId, Group(nodeName), Name("insertFail"))
 
     if (cacheSize.lowerBound == 0) {
       new SummerBuilder {
@@ -69,13 +69,13 @@ object BuildSummer {
         }
       }
     } else {
-      val softMemoryFlush = storm.getOrElse(dag, node, DEFAULT_SOFT_MEMORY_FLUSH_PERCENT)
+      val softMemoryFlush = builder.getOrElse(node, DEFAULT_SOFT_MEMORY_FLUSH_PERCENT)
       logger.info(s"[$nodeName] softMemoryFlush : ${softMemoryFlush.get}")
 
-      val flushFrequency = storm.getOrElse(dag, node, DEFAULT_FLUSH_FREQUENCY)
+      val flushFrequency = builder.getOrElse(node, DEFAULT_FLUSH_FREQUENCY)
       logger.info(s"[$nodeName] maxWaiting: ${flushFrequency.get}")
 
-      val useAsyncCache = storm.getOrElse(dag, node, DEFAULT_USE_ASYNC_CACHE)
+      val useAsyncCache = builder.getOrElse(node, DEFAULT_USE_ASYNC_CACHE)
       logger.info(s"[$nodeName] useAsyncCache : ${useAsyncCache.get}")
 
       if (!useAsyncCache.get) {
@@ -94,13 +94,13 @@ object BuildSummer {
           }
         }
       } else {
-        val asyncPoolSize = storm.getOrElse(dag, node, DEFAULT_ASYNC_POOL_SIZE)
+        val asyncPoolSize = builder.getOrElse(node, DEFAULT_ASYNC_POOL_SIZE)
         logger.info(s"[$nodeName] asyncPoolSize : ${asyncPoolSize.get}")
 
-        val valueCombinerCrushSize = storm.getOrElse(dag, node, DEFAULT_VALUE_COMBINER_CACHE_SIZE)
+        val valueCombinerCrushSize = builder.getOrElse(node, DEFAULT_VALUE_COMBINER_CACHE_SIZE)
         logger.info(s"[$nodeName] valueCombinerCrushSize : ${valueCombinerCrushSize.get}")
 
-        val doCompact = storm.getOrElse(dag, node, CompactValues.default)
+        val doCompact = builder.getOrElse(node, CompactValues.default)
 
         new SummerBuilder {
           def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -15,6 +15,9 @@ import org.apache.storm.{ Config => BacktypeStormConfig }
 import org.slf4j.LoggerFactory
 import scala.reflect.ClassTag
 
+/**
+ * This class encapsulates logic how to build `StormTopology` from DAG of the job, jobId and options.
+ */
 case class StormTopologyBuilder(options: Map[String, Options], jobId: JobId, stormDag: Dag[Storm]) {
   @transient private val logger = LoggerFactory.getLogger(classOf[StormTopologyBuilder])
 
@@ -52,7 +55,6 @@ case class StormTopologyBuilder(options: Map[String, Options], jobId: JobId, sto
   }
 
   private def scheduleSummerBolt(node: SummerNode[Storm], topologyBuilder: TopologyBuilder): Unit = {
-
     val nodeName = getNodeName(node)
 
     def sinkBolt[K, V](summer: Summer[Storm, K, V]): BaseBolt[_, _] = {
@@ -79,9 +81,9 @@ case class StormTopologyBuilder(options: Map[String, Options], jobId: JobId, sto
       logger.info(s"[$nodeName] maxExecutePerSec : $maxExecutePerSec")
 
       val storeBaseFMOp = { op: (ExecutorKeyType, (Option[ExecutorValueType], ExecutorValueType)) =>
-        val ((k, batchID), (optiVWithTS, (ts, v))) = op
-        val optiV = optiVWithTS.map(_._2)
-        List((ts, (k, (optiV, v))))
+        val ((key, batchID), (optPrevExecutorValue, (timestamp, value))) = op
+        val optPrevValue = optPrevExecutorValue.map(_._2)
+        List((timestamp, (key, (optPrevValue, value))))
       }
 
       val flatmapOp: FlatMapOperation[(ExecutorKeyType, (Option[ExecutorValueType], ExecutorValueType)), ExecutorOutputType] =

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -1,0 +1,157 @@
+package com.twitter.summingbird.storm
+
+import com.twitter.summingbird.{ Options, Summer }
+import com.twitter.summingbird.batch.{ BatchID, Timestamp }
+import com.twitter.summingbird.online.{ FlatMapOperation, MergeableStoreFactory, WrappedTSInMergeable, executor }
+import com.twitter.summingbird.online.option.IncludeSuccessHandler
+import com.twitter.summingbird.option.JobId
+import com.twitter.summingbird.planner.{ Dag, FlatMapNode, SourceNode, SummerNode }
+import com.twitter.summingbird.storm.Constants._
+import com.twitter.summingbird.storm.option.AnchorTuples
+import com.twitter.summingbird.storm.planner.StormNode
+import org.apache.storm.generated.StormTopology
+import org.apache.storm.topology.TopologyBuilder
+import org.apache.storm.{ Config => BacktypeStormConfig }
+import org.slf4j.LoggerFactory
+import scala.reflect.ClassTag
+
+case class StormTopologyBuilder(options: Map[String, Options], jobId: JobId, stormDag: Dag[Storm]) {
+  @transient private val logger = LoggerFactory.getLogger(classOf[StormTopologyBuilder])
+
+  def build(): StormTopology = {
+    val topologyBuilder = new TopologyBuilder
+    stormDag.nodes.foreach {
+      case summerNode: SummerNode[Storm] => scheduleSummerBolt(summerNode, topologyBuilder)
+      case flatMapNode: FlatMapNode[Storm] => scheduleFlatMapper(flatMapNode, topologyBuilder)
+      case sourceNode: SourceNode[Storm] => scheduleSpout(sourceNode, topologyBuilder)
+    }
+    topologyBuilder.createTopology()
+  }
+
+  /**
+   * Set storm to tick our nodes every second to clean up finished futures
+   */
+  private def tickConfig = {
+    val boltConfig = new BacktypeStormConfig
+    boltConfig.put(BacktypeStormConfig.TOPOLOGY_TICK_TUPLE_FREQ_SECS, java.lang.Integer.valueOf(1))
+    boltConfig
+  }
+
+  private def scheduleFlatMapper(node: FlatMapNode[Storm], topologyBuilder: TopologyBuilder) = {
+    val bolt: BaseBolt[Any, Any] = FlatMapBoltProvider(this, node).apply
+
+    val parallelism = getOrElse(node, DEFAULT_FM_PARALLELISM).parHint
+    val declarer = topologyBuilder.setBolt(getNodeName(node), bolt, parallelism).addConfigurations(tickConfig)
+    bolt.applyGroupings(declarer)
+  }
+
+  private def scheduleSpout(node: SourceNode[Storm], topologyBuilder: TopologyBuilder) = {
+    val nodeName = stormDag.getNodeName(node)
+    val (sourceParalleism, stormSpout) = SpoutProvider(this, node).apply
+    topologyBuilder.setSpout(nodeName, stormSpout, sourceParalleism)
+  }
+
+  private def scheduleSummerBolt(node: SummerNode[Storm], topologyBuilder: TopologyBuilder): Unit = {
+
+    val nodeName = getNodeName(node)
+
+    def sinkBolt[K, V](summer: Summer[Storm, K, V]): BaseBolt[_, _] = {
+      implicit val semigroup = summer.semigroup
+      implicit val batcher = summer.store.mergeableBatcher
+
+      type ExecutorKeyType = (K, BatchID)
+      type ExecutorValueType = (Timestamp, V)
+      type ExecutorOutputType = (Timestamp, (K, (Option[V], V)))
+
+      val anchorTuples = getOrElse(node, AnchorTuples.default)
+      val metrics = getOrElse(node, DEFAULT_SUMMER_STORM_METRICS)
+      val shouldEmit = stormDag.dependantsOf(node).size > 0
+
+      val builder = BuildSummer(this, node)
+
+      val ackOnEntry = getOrElse(node, DEFAULT_ACK_ON_ENTRY)
+      logger.info(s"[$nodeName] ackOnEntry : ${ackOnEntry.get}")
+
+      val maxEmitPerExecute = getOrElse(node, DEFAULT_MAX_EMIT_PER_EXECUTE)
+      logger.info(s"[$nodeName] maxEmitPerExecute : ${maxEmitPerExecute.get}")
+
+      val maxExecutePerSec = getOrElse(node, DEFAULT_MAX_EXECUTE_PER_SEC)
+      logger.info(s"[$nodeName] maxExecutePerSec : $maxExecutePerSec")
+
+      val storeBaseFMOp = { op: (ExecutorKeyType, (Option[ExecutorValueType], ExecutorValueType)) =>
+        val ((k, batchID), (optiVWithTS, (ts, v))) = op
+        val optiV = optiVWithTS.map(_._2)
+        List((ts, (k, (optiV, v))))
+      }
+
+      val flatmapOp: FlatMapOperation[(ExecutorKeyType, (Option[ExecutorValueType], ExecutorValueType)), ExecutorOutputType] =
+        FlatMapOperation.apply(storeBaseFMOp)
+
+      val supplier: MergeableStoreFactory[ExecutorKeyType, V] = summer.store
+
+      val dependenciesNames = stormDag.dependenciesOf(node).collect { case x: StormNode => getNodeName(x) }
+      val inputEdges = dependenciesNames.map(parent =>
+        (parent, EdgeType.AggregatedKeyValues[ExecutorKeyType, ExecutorValueType](getSummerKeyValueShards(node)))
+      ).toMap
+
+      BaseBolt(
+        jobId,
+        metrics.metrics,
+        anchorTuples,
+        shouldEmit,
+        ackOnEntry,
+        maxExecutePerSec,
+        inputEdges,
+        // Output edge's grouping isn't important for now.
+        EdgeType.itemWithLocalOrShuffleGrouping[ExecutorOutputType],
+        new executor.Summer(
+          () => new WrappedTSInMergeable(supplier.mergeableStore(semigroup)),
+          flatmapOp,
+          getOrElse(node, DEFAULT_ONLINE_SUCCESS_HANDLER),
+          getOrElse(node, DEFAULT_ONLINE_EXCEPTION_HANDLER),
+          builder,
+          getOrElse(node, DEFAULT_MAX_WAITING_FUTURES),
+          getOrElse(node, DEFAULT_MAX_FUTURE_WAIT_TIME),
+          maxEmitPerExecute,
+          getOrElse(node, IncludeSuccessHandler.default))
+      )
+    }
+
+    val summerUntyped = node.members.collect { case c@Summer(_, _, _) => c }.head
+    val parallelism = getOrElse(node, DEFAULT_SUMMER_PARALLELISM).parHint
+    val bolt = sinkBolt(summerUntyped)
+    val declarer =
+      topologyBuilder.setBolt(
+        nodeName,
+        bolt,
+        parallelism
+      ).addConfigurations(tickConfig)
+    bolt.applyGroupings(declarer)
+  }
+
+  private[storm] def getOrElse[T <: AnyRef: ClassTag](node: StormNode, default: T): T =
+    get[T](node) match {
+      case None =>
+        logger.debug(s"Node (${getNodeName(node)}): Using default setting $default")
+        default
+      case Some((namedSource, option)) =>
+        logger.info(s"Node ${getNodeName(node)}: Using $option found via NamedProducer ${'"'}$namedSource${'"'}")
+        option
+    }
+
+  private[storm] def get[T <: AnyRef: ClassTag](node: StormNode): Option[(String, T)] = {
+    val producer = node.members.last
+    Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
+  }
+
+  private[storm] def getSummerKeyValueShards(summer: SummerNode[Storm]): executor.KeyValueShards = {
+    // Query to get the summer paralellism of the summer down stream of us we are emitting to
+    // to ensure no edge case between what we might see for its parallelism and what it would see/pass to storm.
+    val summerParalellism = getOrElse(summer, DEFAULT_SUMMER_PARALLELISM)
+    val summerBatchMultiplier = getOrElse(summer, DEFAULT_SUMMER_BATCH_MULTIPLIER)
+
+    executor.KeyValueShards(summerParalellism.parHint * summerBatchMultiplier.get)
+  }
+
+  private[storm] def getNodeName(node: StormNode) = stormDag.getNodeName(node)
+}


### PR DESCRIPTION
This PR introduces `StormTopologyBuilder` class and move all `Topology` creation code from `Storm` platform to it, to make it easier to read.

Apart from that this PR doesn't contain any changes in logic.