### PR TITLE
Make travis CI more stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ matrix:
   include:
     - scala: 2.10.6
       jdk: oraclejdk8
-      script: ./sbt -Dlog4j.configuration=$LOG4J ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
+      script: ./sbt -Dlog4j.configuration=$LOG4J -DsequentialExecution=true ++$TRAVIS_SCALA_VERSION test mimaReportBinaryIssues
 
     - scala: 2.11.8
       jdk: oraclejdk8
-      script: ./sbt -Dlog4j.configuration=$LOG4J ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
+      script: ./sbt -Dlog4j.configuration=$LOG4J -DsequentialExecution=true ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
 
 def isScala210x(scalaVersion: String) = scalaBinaryVersion(scalaVersion) == "2.10"
 
+def sequentialExecution: Boolean =
+  Option(System.getProperty("sequentialExecution")).map(_.toBoolean).getOrElse(false)
+
 val algebirdVersion = "0.12.0"
 val bijectionVersion = "0.9.1"
 val chillVersion = "0.8.3"
@@ -34,7 +37,18 @@ val chainVersion = "0.1.0"
 
 val extraSettings = mimaDefaultSettings
 
-val sharedSettings = extraSettings ++ Seq(
+val executionSettings = if (sequentialExecution) {
+//  Looks like this is the only way of running tests sequentially:
+//  https://github.com/sbt/sbt/issues/882
+  Seq(
+    parallelExecution in Global := false,
+    parallelExecution in Compile := true
+  )
+} else {
+  Seq(parallelExecution in Test := true)
+}
+
+val sharedSettings = extraSettings ++ executionSettings ++ Seq(
   organization := "com.twitter",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.5", "2.11.7"),
@@ -65,8 +79,6 @@ val sharedSettings = extraSettings ++ Seq(
     "Conjars Repository" at "http://conjars.org/repo",
     "Twitter Maven" at "http://maven.twttr.com"
   ),
-
-  parallelExecution in Test := true,
 
   scalacOptions ++= Seq(
     "-unchecked",


### PR DESCRIPTION
I did some investigation and found that disabling any kind of parallelism for tests on travis greatly improves success rates for our tests. It doesn't feel like a good solution but I think it worth merging until we fix our tests properly. Right now it's almost impossible to pass storm tests.

What do you think @pankajroark @johnynek ?