### PR TITLE
Introduce ability to use grouping for `leftJoin`

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/planner/Node.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/planner/Node.scala
@@ -29,6 +29,12 @@ sealed trait Node[P <: Platform[P]] {
    */
   val members: List[Producer[P, _]] = List()
 
+  /**
+   * @return first producer in producers chain which corresponds to this node,
+   *         i.e. if you have `leftJoin(...).flatMap(...)` on node it returns `leftJoin`.
+   */
+  def firstProducer: Option[Producer[P, _]] = members.lastOption
+
   def toSource: SourceNode[P] = SourceNode(this.members)
 
   def toSummer: SummerNode[P] = SummerNode(this.members)

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -132,3 +132,10 @@ object FMMergeableWithSource {
   val default: FMMergeableWithSource = FMMergeableWithSource(false)
 }
 
+case class LeftJoinGrouping(get: LeftJoinGrouping.Grouping)
+
+object LeftJoinGrouping {
+  sealed trait Grouping
+  case object Shuffle extends Grouping
+  case object Grouped extends Grouping
+}

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -132,10 +132,16 @@ object FMMergeableWithSource {
   val default: FMMergeableWithSource = FMMergeableWithSource(false)
 }
 
-case class LeftJoinGrouping(get: LeftJoinGrouping.Grouping)
+case class LeftJoinGrouping(get: Grouping)
 
 object LeftJoinGrouping {
-  sealed trait Grouping
+  val Grouped: LeftJoinGrouping = LeftJoinGrouping(Grouping.Group)
+  val Shuffled: LeftJoinGrouping = LeftJoinGrouping(Grouping.Shuffle)
+}
+
+sealed trait Grouping
+
+object Grouping {
   case object Shuffle extends Grouping
-  case object Grouped extends Grouping
+  case object Group extends Grouping
 }

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
@@ -83,14 +83,13 @@ class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Produce
   private def dependsOnSummerProducer(p: Prod[_]): Boolean =
     Producer.dependenciesOf(p).collect { case s: Summer[_, _, _] => s }.headOption.isDefined
 
-  private def isGroupedLeftJoin(p: Prod[_]): Boolean =
-    p match {
-      case LeftJoinedProducer(_, _) =>
-        get[LeftJoinGrouping](p).map { case (_, leftJoinGrouping) =>
-          leftJoinGrouping.get
-        } == Some(LeftJoinGrouping.Grouped)
-      case _ => false
-    }
+  private def isGroupedLeftJoin(p: Prod[_]): Boolean = p match {
+    case LeftJoinedProducer(_, _) =>
+      get[LeftJoinGrouping](p).map { case (_, leftJoinGrouping) =>
+        leftJoinGrouping.get
+      } == Some(LeftJoinGrouping.Grouped)
+    case _ => false
+  }
 
   /*
    * Note that this is transitive: we check on p, then we call this fn

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
@@ -19,7 +19,7 @@ package com.twitter.summingbird.planner
 import com.twitter.summingbird._
 import scala.reflect.ClassTag
 import com.twitter.summingbird.online.OnlineDefaultConstants
-import com.twitter.summingbird.online.option.LeftJoinGrouping
+import com.twitter.summingbird.online.option.{ Grouping, LeftJoinGrouping }
 
 class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Producer[P, _], List[String]], options: Map[String, Options]) {
   private type Prod[T] = Producer[P, T]
@@ -87,7 +87,7 @@ class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Produce
     case LeftJoinedProducer(_, _) =>
       get[LeftJoinGrouping](p).map { case (_, leftJoinGrouping) =>
         leftJoinGrouping.get
-      } == Some(LeftJoinGrouping.Grouped)
+      } == Some(Grouping.Group)
     case _ => false
   }
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/planner/OnlinePlan.scala
@@ -19,6 +19,7 @@ package com.twitter.summingbird.planner
 import com.twitter.summingbird._
 import scala.reflect.ClassTag
 import com.twitter.summingbird.online.OnlineDefaultConstants
+import com.twitter.summingbird.online.option.LeftJoinGrouping
 
 class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Producer[P, _], List[String]], options: Map[String, Options]) {
   private type Prod[T] = Producer[P, T]
@@ -81,6 +82,15 @@ class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Produce
 
   private def dependsOnSummerProducer(p: Prod[_]): Boolean =
     Producer.dependenciesOf(p).collect { case s: Summer[_, _, _] => s }.headOption.isDefined
+
+  private def isGroupedLeftJoin(p: Prod[_]): Boolean =
+    p match {
+      case LeftJoinedProducer(_, _) =>
+        get[LeftJoinGrouping](p).map { case (_, leftJoinGrouping) =>
+          leftJoinGrouping.get
+        } == Some(LeftJoinGrouping.Grouped)
+      case _ => false
+    }
 
   /*
    * Note that this is transitive: we check on p, then we call this fn
@@ -169,6 +179,7 @@ class OnlinePlan[P <: Platform[P], V](tail: Producer[P, V], nameMap: Map[Produce
            * then split now.
            */
           case _ if ((!mergableWithSource(currentProducer)) && allTransDepsMergeableWithSource(dep)) => true
+          case _ if isGroupedLeftJoin(currentProducer) => true
           case _ => false
         }
         // Note the currentProducer is *ALREADY* a part of activeBolt

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/TopologyPlannerLaws.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/TopologyPlannerLaws.scala
@@ -98,7 +98,7 @@ object TopologyPlannerLaws extends Properties("Online Dag") {
 
   property("The first producer in a online node cannot be a NamedProducer") = forAll { (dag: MemoryDag) =>
     dag.nodes.forall { n =>
-      val inError = n.members.last.isInstanceOf[NamedProducer[_, _]]
+      val inError = n.firstProducer.get.isInstanceOf[NamedProducer[_, _]]
       if (inError) dumpGraph(dag)
       !inError
     }
@@ -156,8 +156,7 @@ object TopologyPlannerLaws extends Properties("Online Dag") {
 
   property("Prior to a summer the Node should be a FlatMap Node") = forAll { (dag: MemoryDag) =>
     dag.nodes.forall { n =>
-      val firstP = n.members.last
-      val success = firstP match {
+      val success = n.firstProducer.get match {
         case Summer(_, _, _) =>
           dag.dependenciesOf(n).size > 0 && dag.dependenciesOf(n).forall { otherN =>
             otherN.isInstanceOf[FlatMapNode[_]]

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormLaws.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormLaws.scala
@@ -224,7 +224,7 @@ class StormLaws extends WordSpec {
   "StormPlatform should work with grouped leftJoin" in {
     val leftJoinName = "leftJoin"
     val producer = TestPlatform.source(sample[List[Int]])
-      .map(sample[(Int) => (Int, Int)])
+      .map(sample[Int => (Int, Int)])
       .leftJoin(TestPlatform.service(v => Some(v))).name("leftJoin")
       .map(v => (v._1, v._2._1))
       .sumByKey(TestPlatform.store("store"))

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormLaws.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormLaws.scala
@@ -238,6 +238,12 @@ class StormLaws extends WordSpec {
     )))
   }
 
+  "StormPlatform should work with mapValues" in {
+    testProducer(TestPlatform.source(sample[List[(Int, Int)]])
+      .mapValues(identity)
+      .sumByKey(TestPlatform.store("store")))
+  }
+
   def testProducer[T](producer: TailProducer[TestPlatform, T])(implicit storm: Storm): Unit = {
     val memoryResult = MemoryTestExecutor(producer)
     val stormResult = StormTestExecutor(producer, storm)

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
@@ -52,7 +52,7 @@ class StormTopologyBuilderTests extends WordSpec {
         .leftJoin(
           ReadableServiceFactory[Int, Int](() => ReadableStore.fromFn(v => Some(v)))
         ).name(leftJoinName)
-        .map { case (key, (value, optPrevValue)) => (key, value) }
+        .mapValues { case (value, _) => value }
         .sumByKey(TestStore.createStore[Int, Int]()._2)
 
     val topologyWithoutGrouping = buildTopology(producer)

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
@@ -67,6 +67,7 @@ class StormTopologyBuilderTests extends WordSpec {
       leftJoinName -> Options().set(LeftJoinGrouping.Grouped)
     ))
     assert(topologyWithGrouping.spouts.size == 1)
+    // Can be two if we will be able to merge `leftJoin`, `mapValues` and `sumByKey`.
     assert(topologyWithGrouping.bolts.size == 3)
     assert(topologyWithGrouping.edges.map(_.grouping).exists { grouping =>
       grouping == EdgeGrouping.Fields(List(EdgeFormats.Key))

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/StormTopologyBuilderTests.scala
@@ -1,0 +1,81 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.summingbird.storm
+
+import com.twitter.storehaus.ReadableStore
+import com.twitter.summingbird._
+import com.twitter.summingbird.batch.Batcher
+import com.twitter.summingbird.online.ReadableServiceFactory
+import com.twitter.summingbird.online.option._
+import com.twitter.summingbird.option.JobId
+import com.twitter.summingbird.planner.OnlinePlan
+import com.twitter.summingbird.storm.builder.{EdgeGrouping, Topology}
+import com.twitter.summingbird.storm.spout.TraversableSpout
+import org.scalacheck._
+import org.scalatest.WordSpec
+
+class StormTopologyBuilderTests extends WordSpec {
+  // This is dangerous, obviously. The Storm platform graphs tested
+  // here use the UnitBatcher, so the actual time extraction isn't
+  // needed.
+  implicit def extractor[T]: TimeExtractor[T] = TimeExtractor(_ => 0L)
+  implicit val batcher = Batcher.unit
+
+  /**
+   * The function tested below. We can't generate a function with
+   * ScalaCheck, as we need to know the number of tuples that the
+   * flatMap will produce.
+   */
+  val testFn = { i: Int => List((i -> i)) }
+
+  def sample[T: Arbitrary]: T = Arbitrary.arbitrary[T].sample.get
+
+  "Grouped leftJoin creates fields grouping" in {
+    val leftJoinName = "leftJoin"
+    val producer: TailProducer[Storm, _] =
+      Storm.source(TraversableSpout(sample[List[Int]]))
+        .flatMap(testFn)
+        .leftJoin(
+          ReadableServiceFactory[Int, Int](() => ReadableStore.fromFn(v => Some(v)))
+        ).name(leftJoinName)
+        .map { case (key, (value, optPrevValue)) => (key, value) }
+        .sumByKey(TestStore.createStore[Int, Int]()._2)
+
+    val topologyWithoutGrouping = buildTopology(producer)
+    assert(topologyWithoutGrouping.spouts.size == 1)
+    assert(topologyWithoutGrouping.bolts.size == 2)
+    assert(topologyWithoutGrouping.edges.map(_.grouping).forall { grouping =>
+      grouping == EdgeGrouping.Shuffle ||
+        grouping == EdgeGrouping.Fields(List(EdgeFormats.ShardKey))
+    })
+
+    val topologyWithGrouping = buildTopology(producer, Map[String, Options](
+      leftJoinName -> Options().set(LeftJoinGrouping.Grouped)
+    ))
+    assert(topologyWithGrouping.spouts.size == 1)
+    assert(topologyWithGrouping.bolts.size == 3)
+    assert(topologyWithGrouping.edges.map(_.grouping).exists { grouping =>
+      grouping == EdgeGrouping.Fields(List(EdgeFormats.Key))
+    })
+  }
+
+  private def buildTopology(producer: TailProducer[Storm, _], options: Map[String, Options] = Map()): Topology = {
+    val storm = Storm.local(options)
+    val dag = OnlinePlan(producer, options)
+    StormTopologyBuilder(options, JobId("test"), dag).build
+  }
+}

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
@@ -23,6 +23,7 @@ import com.twitter.summingbird.online.option._
 import com.twitter.summingbird.batch.Batcher
 import com.twitter.summingbird.online.ReadableServiceFactory
 import com.twitter.summingbird.option.JobId
+import com.twitter.summingbird.planner.OnlinePlan
 import com.twitter.summingbird.storm.builder.{EdgeGrouping, Topology}
 import com.twitter.summingbird.storm.spout.TraversableSpout
 import org.scalatest.WordSpec
@@ -347,7 +348,7 @@ class TopologyTests extends WordSpec {
 
   private def buildTopology(producer: TailProducer[Storm, _], options: Map[String, Options] = Map()): Topology = {
     val storm = Storm.local(options)
-    val dag = storm.planDag(producer)
+    val dag = OnlinePlan(producer, options)
     StormTopologyBuilder(options, JobId("test"), dag).build
   }
 }

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
@@ -324,7 +324,7 @@ class TopologyTests extends WordSpec {
         .leftJoin(
           ReadableServiceFactory[Int, Int](() => ReadableStore.fromFn(v => Some(v)))
         ).name(leftJoinName)
-        .map(v => (v._1, v._2._1))
+        .map { case (key, (value, optPrevValue)) => (key, value) }
         .sumByKey(TestStore.createStore[Int, Int]()._2)
 
     val topologyWithoutGrouping = buildTopology(producer)

--- a/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
+++ b/summingbird-storm-test/src/test/scala/com/twitter/summingbird/storm/TopologyTests.scala
@@ -17,14 +17,9 @@
 package com.twitter.summingbird.storm
 
 import org.apache.storm.generated.StormTopology
-import com.twitter.storehaus.ReadableStore
 import com.twitter.summingbird._
 import com.twitter.summingbird.online.option._
 import com.twitter.summingbird.batch.Batcher
-import com.twitter.summingbird.online.ReadableServiceFactory
-import com.twitter.summingbird.option.JobId
-import com.twitter.summingbird.planner.OnlinePlan
-import com.twitter.summingbird.storm.builder.{EdgeGrouping, Topology}
 import com.twitter.summingbird.storm.spout.TraversableSpout
 import org.scalatest.WordSpec
 import org.scalacheck._
@@ -315,40 +310,5 @@ class TopologyTests extends WordSpec {
     val TDistMap = bolts.map { case (k, v) => (k.split("-").size - 1, v) }
 
     assert(TDistMap(0).get_common.get_parallelism_hint == 5)
-  }
-
-  "Grouped leftJoin creates fields grouping" in {
-    val leftJoinName = "leftJoin"
-    val producer: TailProducer[Storm, _] =
-      Storm.source(TraversableSpout(sample[List[Int]]))
-        .flatMap(testFn)
-        .leftJoin(
-          ReadableServiceFactory[Int, Int](() => ReadableStore.fromFn(v => Some(v)))
-        ).name(leftJoinName)
-        .map { case (key, (value, optPrevValue)) => (key, value) }
-        .sumByKey(TestStore.createStore[Int, Int]()._2)
-
-    val topologyWithoutGrouping = buildTopology(producer)
-    assert(topologyWithoutGrouping.spouts.size == 1)
-    assert(topologyWithoutGrouping.bolts.size == 2)
-    assert(topologyWithoutGrouping.edges.map(_.grouping).forall { grouping =>
-      grouping == EdgeGrouping.Shuffle ||
-        grouping == EdgeGrouping.Fields(List(EdgeFormats.ShardKey))
-    })
-
-    val topologyWithGrouping = buildTopology(producer, Map[String, Options](
-      leftJoinName -> Options().set(LeftJoinGrouping.Grouped)
-    ))
-    assert(topologyWithGrouping.spouts.size == 1)
-    assert(topologyWithGrouping.bolts.size == 3)
-    assert(topologyWithGrouping.edges.map(_.grouping).exists { grouping =>
-      grouping == EdgeGrouping.Fields(List(EdgeFormats.Key))
-    })
-  }
-
-  private def buildTopology(producer: TailProducer[Storm, _], options: Map[String, Options] = Map()): Topology = {
-    val storm = Storm.local(options)
-    val dag = OnlinePlan(producer, options)
-    StormTopologyBuilder(options, JobId("test"), dag).build
   }
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
@@ -151,8 +151,10 @@ private object EdgeInjections {
     }
 
     override def invert(valueIn: JList[AnyRef]): Try[Item[(K, V)]] = Inversion.attempt(valueIn) { input =>
-      val (timestamp, key, value) = (input.get(0), input.get(1), input.get(2))
-      (timestamp.asInstanceOf[Timestamp], (key.asInstanceOf[K], value.asInstanceOf[V]))
+      val timestamp = input.get(0).asInstanceOf[Timestamp]
+      val key = input.get(1).asInstanceOf[K]
+      val value = input.get(2).asInstanceOf[V]
+      (timestamp, (key, value))
     }
   }
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
@@ -26,18 +26,6 @@ private[storm] object Edges {
     destId
   )
 
-  def shuffleKeyValueToItem[K, V](
-    sourceId: Topology.EmittingId[KeyValue[K, V]],
-    destId: Topology.ReceivingId[Item[(K, V)]],
-    withLocal: Boolean
-  ): Topology.Edge[KeyValue[K, V], Item[(K, V)]] = Topology.Edge(
-    sourceId,
-    EdgeFormats.item[(K, V)],
-    if (withLocal) EdgeGrouping.LocalOrShuffle else EdgeGrouping.Shuffle,
-    identity,
-    destId
-  )
-
   def groupedKeyValueToItem[K, V](
     sourceId: Topology.EmittingId[KeyValue[K, V]],
     destId: Topology.ReceivingId[Item[(K, V)]]
@@ -68,6 +56,17 @@ private[storm] object Edges {
     sourceId,
     EdgeFormats.sharded[K, V],
     if (withLocal) EdgeGrouping.LocalOrShuffle else EdgeGrouping.Shuffle,
+    shardedToItem[K, V],
+    destId
+  )
+
+  def groupedShardedToItem[K, V](
+    sourceId: Topology.EmittingId[Sharded[K, V]],
+    destId: Topology.ReceivingId[Item[(K, V)]]
+  ): Topology.Edge[Sharded[K, V], Item[(K, V)]] = Topology.Edge(
+    sourceId,
+    EdgeFormats.sharded[K, V],
+    EdgeGrouping.Fields(List(EdgeFormats.ShardKey)),
     shardedToItem[K, V],
     destId
   )

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/Edges.scala
@@ -141,17 +141,18 @@ private object EdgeInjections {
   }
 
   case class KeyValueInjection[K, V]() extends Injection[Item[(K, V)], JList[AnyRef]] {
-    override def apply(tuple: Item[(K, V)]): JList[AnyRef] = {
-      val list = new JAList[AnyRef](3)
-      list.add(tuple._1.asInstanceOf[AnyRef])
-      list.add(tuple._2._1.asInstanceOf[AnyRef])
-      list.add(tuple._2._2.asInstanceOf[AnyRef])
-      list
+    override def apply(tuple: Item[(K, V)]): JList[AnyRef] = tuple match {
+      case (timestamp, (key, value)) =>
+        val list = new JAList[AnyRef](3)
+        list.add(timestamp.asInstanceOf[AnyRef])
+        list.add(key.asInstanceOf[AnyRef])
+        list.add(value.asInstanceOf[AnyRef])
+        list
     }
 
     override def invert(valueIn: JList[AnyRef]): Try[Item[(K, V)]] = Inversion.attempt(valueIn) { input =>
-      (input.get(0).asInstanceOf[Timestamp],
-        (input.get(1).asInstanceOf[K], input.get(2).asInstanceOf[V]))
+      val (timestamp, key, value) = (input.get(0), input.get(1), input.get(2))
+      (timestamp.asInstanceOf[Timestamp], (key.asInstanceOf[K], value.asInstanceOf[V]))
     }
   }
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormPlatform.scala
@@ -162,7 +162,7 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
   def withConfigUpdater(fn: SummingbirdConfig => SummingbirdConfig): Storm
 
   def plan[T](tail: TailProducer[Storm, T]): PlannedTopology = {
-    val stormDag = planDag(tail)
+    val stormDag = OnlinePlan(tail, options)
     val config = genConfig(stormDag)
     val jobId = {
       val stormJobId = config.get("storm.job.uniqueId").asInstanceOf[String]
@@ -178,16 +178,6 @@ abstract class Storm(options: Map[String, Options], transformConfig: Summingbird
   }
   def run(tail: TailProducer[Storm, _], jobName: String): Unit = run(plan(tail), jobName)
   def run(plannedTopology: PlannedTopology, jobName: String): Unit
-
-  private[storm] def planDag[T](tail: TailProducer[Storm, T]): Dag[Storm] = {
-    /*
-     * TODO: storm does not yet know about ValueFlatMapped, so remove it before
-     * planning
-     */
-    val dagOptimizer = new DagOptimizer[Storm] {}
-    val stormTail = dagOptimizer.optimize(tail, dagOptimizer.ValueFlatMapToFlatMap)
-    OnlinePlan(stormTail.asInstanceOf[TailProducer[Storm, T]], options)
-  }
 }
 
 class RemoteStorm(options: Map[String, Options], transformConfig: SummingbirdConfig => SummingbirdConfig, passedRegistrars: List[IKryoRegistrar]) extends Storm(options, transformConfig, passedRegistrars) {

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -39,6 +39,7 @@ private[storm] object StormTopologyBuilder {
   // Type to represent simplest values storm components emit.
   // Corresponds to plain [[ Producer[Storm, T] ]] case.
   type Item[T] = (Timestamp, T)
+  type KeyValue[K, V] = Item[(K, V)]
 
   // Types to represent aggregate keys and values components emit in case of partial aggregation.
   type AggregateKey[K] = (K, BatchID)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -255,7 +255,7 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
   }
 
   private def isGroupedLeftJoinNode(node: FlatMapNode[Storm]): Boolean =
-    node.members.last.isInstanceOf[LeftJoinedProducer[Storm, _, _, _]] &&
+    node.firstProducer.get.isInstanceOf[LeftJoinedProducer[Storm, _, _, _]] &&
       get[LeftJoinGrouping](node).map { case (_, leftJoinGrouping) =>
         leftJoinGrouping.get
       } == Some(Grouping.Group)
@@ -307,7 +307,7 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
     }
 
   private[storm] def get[T <: AnyRef: ClassTag](node: StormNode): Option[(String, T)] = {
-    val producer = node.members.last
+    val producer = node.firstProducer.get
     Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
   }
 

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -5,7 +5,7 @@ import com.twitter.summingbird.{ LeftJoinedProducer, Options, Summer }
 import com.twitter.summingbird.batch.{ BatchID, Batcher, Timestamp }
 import com.twitter.summingbird.online.executor
 import com.twitter.summingbird.online.executor.KeyValueShards
-import com.twitter.summingbird.online.option.LeftJoinGrouping
+import com.twitter.summingbird.online.option.{ Grouping, LeftJoinGrouping }
 import com.twitter.summingbird.option.JobId
 import com.twitter.summingbird.planner.{ Dag, FlatMapNode, SourceNode, SummerNode }
 import com.twitter.summingbird.storm.Constants._
@@ -261,7 +261,7 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
     node.members.last.isInstanceOf[LeftJoinedProducer[Storm, _, _, _]] &&
       get[LeftJoinGrouping](node).map { case (_, leftJoinGrouping) =>
         leftJoinGrouping.get
-      } == Some(LeftJoinGrouping.Grouped)
+      } == Some(Grouping.Group)
 
   private def outgoingSummersProps(node: StormNode): Option[OutgoingSummersProps] = {
     val dependants = stormDag.dependantsOf(node)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -93,16 +93,13 @@ private[storm] object StormTopologyBuilder {
 private[storm] case class StormTopologyBuilder(options: Map[String, Options], jobId: JobId, stormDag: Dag[Storm]) {
   import StormTopologyBuilder._
 
-  def build: StormTopology = {
-    val topology = stormDag.nodes.foldLeft(Topology.empty) {
-      case (currentTopology, node: SummerNode[Storm]) =>
-        register(currentTopology, node, SummerBoltProvider(this, node))
-      case (currentTopology, node: FlatMapNode[Storm]) =>
-        register(currentTopology, node, FlatMapBoltProvider(this, node))
-      case (currentTopology, node: SourceNode[Storm]) =>
-        register(currentTopology, node, SpoutProvider(this, node))
-    }
-    topology.build(jobId)
+  def build: Topology = stormDag.nodes.foldLeft(Topology.empty) {
+    case (currentTopology, node: SummerNode[Storm]) =>
+      register(currentTopology, node, SummerBoltProvider(this, node))
+    case (currentTopology, node: FlatMapNode[Storm]) =>
+      register(currentTopology, node, FlatMapBoltProvider(this, node))
+    case (currentTopology, node: SourceNode[Storm]) =>
+      register(currentTopology, node, SpoutProvider(this, node))
   }
 
   private def register(topology: Topology, node: StormNode, provider: ComponentProvider): Topology =


### PR DESCRIPTION
This PR adds `LeftJoinGrouping` options which makes flat map nodes which correspond to `LeftJoinProducer` grouped by key. This achieved by couple of changes:
1. introduction of `LeftJoinGrouping` option itself
2. support this option in `OnlinePlan` to force separate node for grouped `leftJoin` producers
3. support grouped `Item[(K, V)]` tuples in `StormTopologyBuilder`
4. tests for this in `StormLaws` and `TopologyTests`.