### PR TITLE
Refactor `SummerBuilder` to make it possible to use `Counters` on `SummerBuilder` creation

### DIFF
--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -2,7 +2,8 @@ package com.twitter.summingbird.online.option
 
 import com.twitter.util.Duration
 import com.twitter.algebird.Semigroup
-import com.twitter.algebird.util.summer.AsyncSummer
+import com.twitter.algebird.util.summer.{ AsyncSummer, Incrementor }
+import com.twitter.summingbird.{ Counter, Name }
 
 case class OnlineSuccessHandler(handlerFn: Unit => Unit)
 
@@ -98,8 +99,17 @@ trait SummerBuilder extends Serializable {
 
 /**
  * The SummerConstructor option, set this instead of CacheSize, AsyncPoolSize, etc.. to provide how to construct the aggregation for this bolt
+ * @see [[Summers]] for useful [[SummerConstructor]]s.
  */
-case class SummerConstructor(get: SummerBuilder)
+case class SummerConstructor(get: SummerConstructor.Context => SummerBuilder)
+
+object SummerConstructor {
+  def apply(get: SummerBuilder): SummerConstructor = SummerConstructor(_ => get)
+
+  trait Context {
+    def counter(name: Name): Counter with Incrementor
+  }
+}
 
 /**
  * How many instances/tasks of this flatmap task should be spawned in the environment

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -99,20 +99,20 @@ trait SummerBuilder extends Serializable {
 
 /**
  * The SummerConstructor option, set this instead of CacheSize, AsyncPoolSize, etc.. to provide how to construct the aggregation for this bolt
- * @see [[Summers]] for useful [[SummerConstructor]]s.
+ * @see [[Summers]] for useful [[SummerWithCountersBuilder]]s.
  */
-case class SummerConstructor(get: SummerConstructorSpec)
+case class SummerConstructor(get: SummerWithCountersBuilder)
 
-trait SummerConstructorSpec {
-  def builder(counter: Name => Counter with Incrementor): SummerBuilder
+trait SummerWithCountersBuilder {
+  def create(counter: Name => Counter with Incrementor): SummerBuilder
 }
 
 object SummerConstructor {
   def apply(get: SummerBuilder): SummerConstructor =
     SummerConstructor(DeprecatedSummerConstructorSpec(get))
 
-  private case class DeprecatedSummerConstructorSpec(get: SummerBuilder) extends SummerConstructorSpec {
-    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = get
+  private case class DeprecatedSummerConstructorSpec(get: SummerBuilder) extends SummerWithCountersBuilder {
+    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = get
   }
 }
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -101,13 +101,18 @@ trait SummerBuilder extends Serializable {
  * The SummerConstructor option, set this instead of CacheSize, AsyncPoolSize, etc.. to provide how to construct the aggregation for this bolt
  * @see [[Summers]] for useful [[SummerConstructor]]s.
  */
-case class SummerConstructor(get: SummerConstructor.Context => SummerBuilder)
+case class SummerConstructor(get: SummerConstructorSpec)
+
+trait SummerConstructorSpec {
+  def builder(counter: Name => Counter with Incrementor): SummerBuilder
+}
 
 object SummerConstructor {
-  def apply(get: SummerBuilder): SummerConstructor = SummerConstructor(_ => get)
+  def apply(get: SummerBuilder): SummerConstructor =
+    SummerConstructor(DeprecatedSummerConstructorSpec(get))
 
-  trait Context {
-    def counter(name: Name): Counter with Incrementor
+  private case class DeprecatedSummerConstructorSpec(get: SummerBuilder) extends SummerConstructorSpec {
+    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = get
   }
 }
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/AllOpts.scala
@@ -103,8 +103,12 @@ trait SummerBuilder extends Serializable {
  */
 case class SummerConstructor(get: SummerWithCountersBuilder)
 
+/**
+ * Returned [[SummerBuilder]] should be [[Serializable]], while [[SummerWithCountersBuilder]]
+ * should be used only on submitter node.
+ */
 trait SummerWithCountersBuilder {
-  def create(counter: Name => Counter with Incrementor): SummerBuilder
+  def create(counter: Name => Incrementor): SummerBuilder
 }
 
 object SummerConstructor {
@@ -112,7 +116,7 @@ object SummerConstructor {
     SummerConstructor(DeprecatedSummerConstructorSpec(get))
 
   private case class DeprecatedSummerConstructorSpec(get: SummerBuilder) extends SummerWithCountersBuilder {
-    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = get
+    override def create(counter: (Name) => Incrementor): SummerBuilder = get
   }
 }
 

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
@@ -2,7 +2,7 @@ package com.twitter.summingbird.online.option
 
 import com.twitter.algebird.Semigroup
 import com.twitter.algebird.util.summer._
-import com.twitter.summingbird.Name
+import com.twitter.summingbird.{ Counter, Name }
 import com.twitter.summingbird.online.OnlineDefaultConstants._
 import com.twitter.summingbird.option.CacheSize
 import com.twitter.util.{ Future, FuturePool }
@@ -36,10 +36,10 @@ object Summers {
     cacheSize, flushFrequency, softMemoryFlushPercent, asyncPoolSize, compactValues, valueCombinerCacheSize
   ))
 
-  private object NullConstructor extends (SummerConstructor.Context => SummerBuilder) {
-    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
-      val tuplesIn = ctx.counter(TuplesInCounterName)
-      val tuplesOut = ctx.counter(TuplesOutCounterName)
+  private case object NullConstructor extends SummerConstructorSpec {
+    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+      val tuplesIn = counter(TuplesInCounterName)
+      val tuplesOut = counter(TuplesOutCounterName)
       new SummerBuilder {
         override def getSummer[K, V: Semigroup]: AsyncSummer[(K, V), Map[K, V]] =
           new com.twitter.algebird.util.summer.NullSummer[K, V](tuplesIn, tuplesOut)
@@ -51,14 +51,14 @@ object Summers {
     cacheSize: CacheSize,
     flushFrequency: FlushFrequency,
     softMemoryFlushPercent: SoftMemoryFlushPercent
-  ) extends (SummerConstructor.Context => SummerBuilder) {
-    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
-      val memoryCounter = ctx.counter(MemoryCounterName)
-      val timeoutCounter = ctx.counter(TimeoutCounterName)
-      val sizeCounter = ctx.counter(SizeCounterName)
-      val tupleInCounter = ctx.counter(TuplesInCounterName)
-      val tupleOutCounter = ctx.counter(TuplesOutCounterName)
-      val insertCounter = ctx.counter(InsertCounterName)
+  ) extends SummerConstructorSpec {
+    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+      val memoryCounter = counter(MemoryCounterName)
+      val timeoutCounter = counter(TimeoutCounterName)
+      val sizeCounter = counter(SizeCounterName)
+      val tupleInCounter = counter(TuplesInCounterName)
+      val tupleOutCounter = counter(TuplesOutCounterName)
+      val insertCounter = counter(InsertCounterName)
 
       new SummerBuilder {
         def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {
@@ -84,15 +84,15 @@ object Summers {
     asyncPoolSize: AsyncPoolSize,
     compactValues: CompactValues,
     valueCombinerCacheSize: ValueCombinerCacheSize
-  ) extends (SummerConstructor.Context => SummerBuilder) {
-    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
-      val memoryCounter = ctx.counter(MemoryCounterName)
-      val timeoutCounter = ctx.counter(TimeoutCounterName)
-      val sizeCounter = ctx.counter(SizeCounterName)
-      val tupleInCounter = ctx.counter(TuplesInCounterName)
-      val tupleOutCounter = ctx.counter(TuplesOutCounterName)
-      val insertCounter = ctx.counter(InsertCounterName)
-      val insertFailCounter = ctx.counter(InsertFailCounterName)
+  ) extends SummerConstructorSpec {
+    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+      val memoryCounter = counter(MemoryCounterName)
+      val timeoutCounter = counter(TimeoutCounterName)
+      val sizeCounter = counter(SizeCounterName)
+      val tupleInCounter = counter(TuplesInCounterName)
+      val tupleOutCounter = counter(TuplesOutCounterName)
+      val insertCounter = counter(InsertCounterName)
+      val insertFailCounter = counter(InsertFailCounterName)
 
       new SummerBuilder {
         def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
@@ -17,27 +17,8 @@ object Summers {
   val InsertCounterName = Name("inserts")
   val InsertFailCounterName = Name("insertFail")
 
-  val Null = new SummerConstructor(NullConstructor)
-
-  def sync(
-    cacheSize: CacheSize = DEFAULT_FM_CACHE,
-    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
-    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT
-  ): SummerConstructor = new SummerConstructor(SyncConstructor(cacheSize, flushFrequency, softMemoryFlushPercent))
-
-  def async(
-    cacheSize: CacheSize = DEFAULT_FM_CACHE,
-    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
-    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT,
-    asyncPoolSize: AsyncPoolSize = DEFAULT_ASYNC_POOL_SIZE,
-    compactValues: CompactValues = CompactValues.default,
-    valueCombinerCacheSize: ValueCombinerCacheSize = DEFAULT_VALUE_COMBINER_CACHE_SIZE
-  ): SummerConstructor = new SummerConstructor(AsyncConstructor(
-    cacheSize, flushFrequency, softMemoryFlushPercent, asyncPoolSize, compactValues, valueCombinerCacheSize
-  ))
-
-  private case object NullConstructor extends SummerConstructorSpec {
-    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+  case object Null extends SummerWithCountersBuilder {
+    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
       val tuplesIn = counter(TuplesInCounterName)
       val tuplesOut = counter(TuplesOutCounterName)
       new SummerBuilder {
@@ -47,12 +28,12 @@ object Summers {
     }
   }
 
-  private case class SyncConstructor(
-    cacheSize: CacheSize,
-    flushFrequency: FlushFrequency,
-    softMemoryFlushPercent: SoftMemoryFlushPercent
-  ) extends SummerConstructorSpec {
-    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+  case class Sync(
+    cacheSize: CacheSize = DEFAULT_FM_CACHE,
+    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
+    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT
+  ) extends SummerWithCountersBuilder {
+    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
       val memoryCounter = counter(MemoryCounterName)
       val timeoutCounter = counter(TimeoutCounterName)
       val sizeCounter = counter(SizeCounterName)
@@ -77,15 +58,15 @@ object Summers {
     }
   }
 
-  private case class AsyncConstructor(
-    cacheSize: CacheSize,
-    flushFrequency: FlushFrequency,
-    softMemoryFlushPercent: SoftMemoryFlushPercent,
-    asyncPoolSize: AsyncPoolSize,
-    compactValues: CompactValues,
-    valueCombinerCacheSize: ValueCombinerCacheSize
-  ) extends SummerConstructorSpec {
-    override def builder(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+  case class Async(
+    cacheSize: CacheSize = DEFAULT_FM_CACHE,
+    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
+    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT,
+    asyncPoolSize: AsyncPoolSize = DEFAULT_ASYNC_POOL_SIZE,
+    compactValues: CompactValues = CompactValues.default,
+    valueCombinerCacheSize: ValueCombinerCacheSize = DEFAULT_VALUE_COMBINER_CACHE_SIZE
+  ) extends SummerWithCountersBuilder {
+    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
       val memoryCounter = counter(MemoryCounterName)
       val timeoutCounter = counter(TimeoutCounterName)
       val sizeCounter = counter(SizeCounterName)

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
@@ -1,0 +1,124 @@
+package com.twitter.summingbird.online.option
+
+import com.twitter.algebird.Semigroup
+import com.twitter.algebird.util.summer._
+import com.twitter.summingbird.Name
+import com.twitter.summingbird.online.OnlineDefaultConstants._
+import com.twitter.summingbird.option.CacheSize
+import com.twitter.util.{ Future, FuturePool }
+import java.util.concurrent.{ Executors, TimeUnit }
+
+object Summers {
+  val MemoryCounterName = Name("memory")
+  val TimeoutCounterName = Name("timeout")
+  val SizeCounterName = Name("size")
+  val TuplesInCounterName = Name("tuplesIn")
+  val TuplesOutCounterName = Name("tuplesOut")
+  val InsertCounterName = Name("inserts")
+  val InsertFailCounterName = Name("insertFail")
+
+  val Null = new SummerConstructor(NullConstructor)
+
+  def sync(
+    cacheSize: CacheSize = DEFAULT_FM_CACHE,
+    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
+    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT
+  ): SummerConstructor = new SummerConstructor(SyncConstructor(cacheSize, flushFrequency, softMemoryFlushPercent))
+
+  def async(
+    cacheSize: CacheSize = DEFAULT_FM_CACHE,
+    flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
+    softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT,
+    asyncPoolSize: AsyncPoolSize = DEFAULT_ASYNC_POOL_SIZE,
+    compactValues: CompactValues = CompactValues.default,
+    valueCombinerCacheSize: ValueCombinerCacheSize = DEFAULT_VALUE_COMBINER_CACHE_SIZE
+  ): SummerConstructor = new SummerConstructor(AsyncConstructor(
+    cacheSize, flushFrequency, softMemoryFlushPercent, asyncPoolSize, compactValues, valueCombinerCacheSize
+  ))
+
+  private object NullConstructor extends (SummerConstructor.Context => SummerBuilder) {
+    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
+      val tuplesIn = ctx.counter(TuplesInCounterName)
+      val tuplesOut = ctx.counter(TuplesOutCounterName)
+      new SummerBuilder {
+        override def getSummer[K, V: Semigroup]: AsyncSummer[(K, V), Map[K, V]] =
+          new com.twitter.algebird.util.summer.NullSummer[K, V](tuplesIn, tuplesOut)
+      }
+    }
+  }
+
+  private case class SyncConstructor(
+    cacheSize: CacheSize,
+    flushFrequency: FlushFrequency,
+    softMemoryFlushPercent: SoftMemoryFlushPercent
+  ) extends (SummerConstructor.Context => SummerBuilder) {
+    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
+      val memoryCounter = ctx.counter(MemoryCounterName)
+      val timeoutCounter = ctx.counter(TimeoutCounterName)
+      val sizeCounter = ctx.counter(SizeCounterName)
+      val tupleInCounter = ctx.counter(TuplesInCounterName)
+      val tupleOutCounter = ctx.counter(TuplesOutCounterName)
+      val insertCounter = ctx.counter(InsertCounterName)
+
+      new SummerBuilder {
+        def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {
+          new SyncSummingQueue[K, V](
+            BufferSize(cacheSize.lowerBound),
+            com.twitter.algebird.util.summer.FlushFrequency(flushFrequency.get),
+            MemoryFlushPercent(softMemoryFlushPercent.get),
+            memoryCounter,
+            timeoutCounter,
+            sizeCounter,
+            insertCounter,
+            tupleInCounter,
+            tupleOutCounter)
+        }
+      }
+    }
+  }
+
+  private case class AsyncConstructor(
+    cacheSize: CacheSize,
+    flushFrequency: FlushFrequency,
+    softMemoryFlushPercent: SoftMemoryFlushPercent,
+    asyncPoolSize: AsyncPoolSize,
+    compactValues: CompactValues,
+    valueCombinerCacheSize: ValueCombinerCacheSize
+  ) extends (SummerConstructor.Context => SummerBuilder) {
+    override def apply(ctx: SummerConstructor.Context): SummerBuilder = {
+      val memoryCounter = ctx.counter(MemoryCounterName)
+      val timeoutCounter = ctx.counter(TimeoutCounterName)
+      val sizeCounter = ctx.counter(SizeCounterName)
+      val tupleInCounter = ctx.counter(TuplesInCounterName)
+      val tupleOutCounter = ctx.counter(TuplesOutCounterName)
+      val insertCounter = ctx.counter(InsertCounterName)
+      val insertFailCounter = ctx.counter(InsertFailCounterName)
+
+      new SummerBuilder {
+        def getSummer[K, V: Semigroup]: com.twitter.algebird.util.summer.AsyncSummer[(K, V), Map[K, V]] = {
+          val executor = Executors.newFixedThreadPool(asyncPoolSize.get)
+          val futurePool = FuturePool(executor)
+          val summer = new AsyncListSum[K, V](BufferSize(cacheSize.lowerBound),
+            com.twitter.algebird.util.summer.FlushFrequency(flushFrequency.get),
+            MemoryFlushPercent(softMemoryFlushPercent.get),
+            memoryCounter,
+            timeoutCounter,
+            insertCounter,
+            insertFailCounter,
+            sizeCounter,
+            tupleInCounter,
+            tupleOutCounter,
+            futurePool,
+            Compact(compactValues.toBoolean),
+            CompactionSize(valueCombinerCacheSize.get))
+          summer.withCleanup(() => {
+            Future {
+              executor.shutdown
+              executor.awaitTermination(10, TimeUnit.SECONDS)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
+++ b/summingbird-online/src/main/scala/com/twitter/summingbird/online/option/Summers.scala
@@ -2,7 +2,7 @@ package com.twitter.summingbird.online.option
 
 import com.twitter.algebird.Semigroup
 import com.twitter.algebird.util.summer._
-import com.twitter.summingbird.{ Counter, Name }
+import com.twitter.summingbird.Name
 import com.twitter.summingbird.online.OnlineDefaultConstants._
 import com.twitter.summingbird.option.CacheSize
 import com.twitter.util.{ Future, FuturePool }
@@ -18,7 +18,7 @@ object Summers {
   val InsertFailCounterName = Name("insertFail")
 
   case object Null extends SummerWithCountersBuilder {
-    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+    override def create(counter: (Name) => Incrementor): SummerBuilder = {
       val tuplesIn = counter(TuplesInCounterName)
       val tuplesOut = counter(TuplesOutCounterName)
       new SummerBuilder {
@@ -33,7 +33,7 @@ object Summers {
     flushFrequency: FlushFrequency = DEFAULT_FLUSH_FREQUENCY,
     softMemoryFlushPercent: SoftMemoryFlushPercent = DEFAULT_SOFT_MEMORY_FLUSH_PERCENT
   ) extends SummerWithCountersBuilder {
-    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+    override def create(counter: (Name) => Incrementor): SummerBuilder = {
       val memoryCounter = counter(MemoryCounterName)
       val timeoutCounter = counter(TimeoutCounterName)
       val sizeCounter = counter(SizeCounterName)
@@ -66,7 +66,7 @@ object Summers {
     compactValues: CompactValues = CompactValues.default,
     valueCombinerCacheSize: ValueCombinerCacheSize = DEFAULT_VALUE_COMBINER_CACHE_SIZE
   ) extends SummerWithCountersBuilder {
-    override def create(counter: (Name) => Counter with Incrementor): SummerBuilder = {
+    override def create(counter: (Name) => Incrementor): SummerBuilder = {
       val memoryCounter = counter(MemoryCounterName)
       val timeoutCounter = counter(TimeoutCounterName)
       val sizeCounter = counter(SizeCounterName)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/BuildSummer.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.summingbird.storm
 
-import com.twitter.algebird.util.summer._
+import com.twitter.algebird.util.summer.Incrementor
 import com.twitter.summingbird.online.OnlineDefaultConstants._
 import com.twitter.summingbird.{ Counter, Group }
 import com.twitter.summingbird.online.option._
@@ -34,10 +34,11 @@ private[storm] object BuildSummer {
 
   def apply(builder: StormTopologyBuilder, node: StormNode): SummerBuilder = {
     val summerBuilder = builder.get[SummerConstructor](node)
-      .map { case (_, constructor) => constructor.get }.getOrElse {
-      logger.info(s"[${builder.getNodeName(node)}] use legacy way of getting summer builder")
-      legacySummerBuilder(builder, node)
-    }
+      .map { case (_, constructor) => constructor.get }
+      .getOrElse {
+        logger.info(s"[${builder.getNodeName(node)}] use legacy way of getting summer builder")
+        legacySummerBuilder(builder, node)
+      }
 
     logger.info(s"[${builder.getNodeName(node)}] summer builder: $summerBuilder")
     summerBuilder.create { counterName =>
@@ -65,7 +66,12 @@ private[storm] object BuildSummer {
         val valueCombinerCrushSize = option(DEFAULT_VALUE_COMBINER_CACHE_SIZE)
         val doCompact = option(CompactValues.default)
         Summers.Async(
-          cacheSize, flushFrequency, softMemoryFlush, asyncPoolSize, doCompact, valueCombinerCrushSize
+          cacheSize,
+          flushFrequency,
+          softMemoryFlush,
+          asyncPoolSize,
+          doCompact,
+          valueCombinerCrushSize
         )
       }
     }


### PR DESCRIPTION
Currently the way to customize `Summer` instances is not perfect - we have an old 'legacy' way based on a lot of different options and 'new' way with setting `SummerBuilder` directly. 
At the same time with new way it's impossible to fully utilize `Counters` because `jobId` is needed to create them. Also new way is quite verbose.

This PR adds a way to use `Counters` in `SummerBuilder` and couple of `SummerBuilder`s:  `Null`, `sync` and `async`.