### PR TITLE
Fix summer options propagation

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/planner/Node.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/planner/Node.scala
@@ -35,6 +35,12 @@ sealed trait Node[P <: Platform[P]] {
    */
   def firstProducer: Option[Producer[P, _]] = members.lastOption
 
+  /**
+   * @return last producer in producers chain which corresponds to this node,
+   *         i.e. if you have `leftJoin(...).flatMap(...)` on node it returns `flatMap`.
+   */
+  def lastProducer:  Option[Producer[P, _]] = members.headOption
+
   def toSource: SourceNode[P] = SourceNode(this.members)
 
   def toSummer: SummerNode[P] = SummerNode(this.members)

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/FlatMapBoltProvider.scala
@@ -111,7 +111,7 @@ private[storm] case class FlatMapBoltProvider(
     val operation = foldOperations[T, (K, V)](node.members.reverse)
     val wrappedOperation = wrapTimeBatchIDKV(operation)(batcher)
 
-    val summerBuilder = BuildSummer(builder, node)
+    val summerBuilder = BuildSummer(builder, nodeName, node.lastProducer.get)
 
     Topology.Bolt(
       parallelism.parHint,

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/SpoutProvider.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/SpoutProvider.scala
@@ -30,8 +30,8 @@ private[storm] case class SpoutProvider(
     semigroup: Semigroup[V]
   ): Option[Topology.Component[Aggregated[K, V]]] = {
     val (tormentaSpout, parallelism) = getTormentaSpoutAndParallelism[(K, V)]
-    val summerBuilder = BuildSummer(builder, node)
     val nodeName = builder.getNodeName(node)
+    val summerBuilder = BuildSummer(builder, nodeName, node.lastProducer.get)
     val flushExecTimeCounter = counter(Group(nodeName), Name("spoutFlushExecTime"))
     val executeTimeCounter = counter(Group(nodeName), Name("spoutEmitExecTime"))
 

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -1,7 +1,7 @@
 package com.twitter.summingbird.storm
 
 import com.twitter.algebird.Semigroup
-import com.twitter.summingbird.{ IdentityKeyedProducer, LeftJoinedProducer, Options, Summer }
+import com.twitter.summingbird.{ LeftJoinedProducer, Options, Summer }
 import com.twitter.summingbird.batch.{ BatchID, Batcher, Timestamp }
 import com.twitter.summingbird.online.executor
 import com.twitter.summingbird.online.executor.KeyValueShards
@@ -309,11 +309,9 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
     }
 
   private[storm] def get[T <: AnyRef: ClassTag](node: StormNode): Option[(String, T)] =
-    node.members
-      .find(!_.isInstanceOf[IdentityKeyedProducer[_, _, _]])
-      .flatMap { producer =>
-        Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
-      }
+    node.firstProducer.flatMap { producer =>
+      Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
+    }
 
   private[storm] def getNodeName(node: StormNode) = stormDag.getNodeName(node)
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -1,7 +1,7 @@
 package com.twitter.summingbird.storm
 
 import com.twitter.algebird.Semigroup
-import com.twitter.summingbird.{ LeftJoinedProducer, Options, Summer }
+import com.twitter.summingbird.{ IdentityKeyedProducer, LeftJoinedProducer, Options, Summer }
 import com.twitter.summingbird.batch.{ BatchID, Batcher, Timestamp }
 import com.twitter.summingbird.online.executor
 import com.twitter.summingbird.online.executor.KeyValueShards
@@ -309,9 +309,11 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
     }
 
   private[storm] def get[T <: AnyRef: ClassTag](node: StormNode): Option[(String, T)] =
-    node.firstProducer.flatMap { producer =>
-      Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
-    }
+    node.members
+      .find(!_.isInstanceOf[IdentityKeyedProducer[_, _, _]])
+      .flatMap { producer =>
+        Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
+      }
 
   private[storm] def getNodeName(node: StormNode) = stormDag.getNodeName(node)
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/StormTopologyBuilder.scala
@@ -1,7 +1,7 @@
 package com.twitter.summingbird.storm
 
 import com.twitter.algebird.Semigroup
-import com.twitter.summingbird.{ LeftJoinedProducer, Options, Summer }
+import com.twitter.summingbird.{ LeftJoinedProducer, Options, Producer, Summer }
 import com.twitter.summingbird.batch.{ BatchID, Batcher, Timestamp }
 import com.twitter.summingbird.online.executor
 import com.twitter.summingbird.online.executor.KeyValueShards
@@ -309,9 +309,10 @@ private[storm] case class StormTopologyBuilder(options: Map[String, Options], jo
     }
 
   private[storm] def get[T <: AnyRef: ClassTag](node: StormNode): Option[(String, T)] =
-    node.firstProducer.flatMap { producer =>
-      Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
-    }
+    node.firstProducer.flatMap { producer => get(producer) }
+
+  private [storm] def get[T <: AnyRef: ClassTag](producer: Producer[Storm, _]): Option[(String, T)] =
+    Options.getFirst[T](options, stormDag.producerToPriorityNames(producer))
 
   private[storm] def getNodeName(node: StormNode) = stormDag.getNodeName(node)
 }

--- a/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/SummerBoltProvider.scala
+++ b/summingbird-storm/src/main/scala/com/twitter/summingbird/storm/SummerBoltProvider.scala
@@ -63,7 +63,7 @@ private[storm] case class SummerBoltProvider(
     val parallelism = getOrElse(DEFAULT_SUMMER_PARALLELISM).parHint
     logger.info(s"[$nodeName] parallelism : $parallelism")
 
-    val summerBuilder = BuildSummer(builder, node)
+    val summerBuilder = BuildSummer(builder, nodeName, summer)
     val storeBaseFMOp: ((AggregateKey[K], (Option[Item[V]], Item[V]))) => TraversableOnce[O] = {
       case ((key, batchID), (optPrevExecutorValue, (timestamp, value))) =>
         val optPrevValue = optPrevExecutorValue.map(_._2)


### PR DESCRIPTION
Currently if you have `flatMap().name('flatMap').sumByKey().name('sumByKey')` and you have some `Summer` options on both `flatMap` and `sumByKey` for both of nodes (for partial aggregation on `flatMap` and for final aggregation on `sumByKey`) only options from `flatMap` will be applied. 

Root cause of this is in a way we get options for `Node`s - we get options for first producer in producers chain corresponding to `Node`. In case of `SummerNode` members contains two `Producer`s - `IdentityKeyedProducer` and `Summer`.

This PR fixes that by passing `Producer` instance to `BuildSummer` which is used to get options for summer.