### PR TITLE
Add a DagOptimizer test

### DIFF
--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 class DagOptimizerTest extends FunSuite {
 
   implicit val generatorDrivenConfig =
-    PropertyCheckConfig(minSuccessful = 10000)
+    PropertyCheckConfig(minSuccessful = 10000, maxDiscarded = 1000) // the producer generator uses filter, I think
 
   import TestGraphGenerators._
   import MemoryArbitraries._

--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
@@ -15,7 +15,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 class DagOptimizerTest extends FunSuite {
 
   implicit val generatorDrivenConfig =
-    PropertyCheckConfig(minSuccessful = 10000, maxDiscarded = 1000) // the producer generator uses filter, I think
+    PropertyCheckConfig(minSuccessful = 1000, maxDiscarded = 1000) // the producer generator uses filter, I think
     //PropertyCheckConfig(minSuccessful = 100, maxDiscarded = 1000) // the producer generator uses filter, I think
 
   import TestGraphGenerators._

--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
@@ -1,0 +1,31 @@
+package com.twitter.summingbird.planner
+
+import com.twitter.summingbird._
+import com.twitter.summingbird.memory._
+
+import org.scalatest.FunSuite
+import org.scalacheck.{Arbitrary, Gen}
+import Gen.oneOf
+
+import scala.collection.mutable
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+class DagOptimizerTest extends FunSuite {
+
+  import TestGraphGenerators._
+  import MemoryArbitraries._
+  implicit def testStore: Memory#Store[Int, Int] = mutable.Map[Int, Int]()
+  implicit def testService: Memory#Service[Int, Int] = new mutable.HashMap[Int, Int]() with MemoryService[Int, Int]
+  implicit def sink1: Memory#Sink[Int] = ((_) => Unit)
+  implicit def sink2: Memory#Sink[(Int, Int)] = ((_) => Unit)
+
+  implicit def genProducer: Arbitrary[Producer[Memory, _]] = Arbitrary(oneOf(genProd1, genProd2, summed))
+
+  test("DagOptimizer round trips") {
+    forAll { p: Producer[Memory, Int] =>
+      val dagOpt = new DagOptimizer[Memory] { }
+
+      assert(dagOpt.toLiteral(p).evaluate == p)
+    }
+  }
+}

--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
@@ -28,4 +28,21 @@ class DagOptimizerTest extends FunSuite {
       assert(dagOpt.toLiteral(p).evaluate == p)
     }
   }
+
+  test("ExpressionDag fanOut matches DependantGraph") {
+    forAll { p: Producer[Memory, Int] =>
+      val dagOpt = new DagOptimizer[Memory] { }
+
+      val expDag = dagOpt.expressionDag(p)._1
+
+      val deps = Dependants(p)
+
+      deps.nodes.foreach { n =>
+        deps.fanOut(n) match {
+          case Some(fo) => assert(expDag.fanOut(n) == fo)
+          case None => fail(s"node $n has no fanOut value")
+        }
+      }
+    }
+  }
 }

--- a/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
+++ b/summingbird-core-test/src/test/scala/com/twitter/summingbird/planner/DagOptimizerTest.scala
@@ -19,7 +19,7 @@ class DagOptimizerTest extends FunSuite {
   implicit def sink1: Memory#Sink[Int] = ((_) => Unit)
   implicit def sink2: Memory#Sink[(Int, Int)] = ((_) => Unit)
 
-  implicit def genProducer: Arbitrary[Producer[Memory, _]] = Arbitrary(oneOf(genProd1, genProd2, summed))
+  def genProducer: Gen[Producer[Memory, _]] = oneOf(genProd1, genProd2, summed)
 
   test("DagOptimizer round trips") {
     forAll { p: Producer[Memory, Int] =>
@@ -30,7 +30,7 @@ class DagOptimizerTest extends FunSuite {
   }
 
   test("ExpressionDag fanOut matches DependantGraph") {
-    forAll { p: Producer[Memory, Int] =>
+    forAll(genProducer) { p: Producer[Memory, _] =>
       val dagOpt = new DagOptimizer[Memory] { }
 
       val expDag = dagOpt.expressionDag(p)._1

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/graph/ExpressionDag.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/graph/ExpressionDag.scala
@@ -355,6 +355,9 @@ trait Rule[N[_]] { self =>
     def apply[T](on: ExpressionDag[N]) = { n =>
       self.apply(on)(n).orElse(that.apply(on)(n))
     }
+
+    override def toString: String =
+      s"$self.orElse($that)"
   }
 }
 

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
@@ -55,7 +55,9 @@ package object graph {
           innerg + (parent -> (child :: innerg.getOrElse(parent, Nil)))
         }
       }
-      // note, we don't distinct the nodes, since we want fanOut(a) in (a ++ a) to be 2
+      // make sure the values are sets, not .mapValues is lazy in scala
+      .map { case (k, v) => (k, v.distinct) }
+
     graph.getOrElse(_, Nil)
   }
 

--- a/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/graph/package.scala
@@ -55,8 +55,7 @@ package object graph {
           innerg + (parent -> (child :: innerg.getOrElse(parent, Nil)))
         }
       }
-      // make sure the values are sets, not .mapValues is lazy in scala
-      .map { case (k, v) => (k, v.distinct) };
+      // note, we don't distinct the nodes, since we want fanOut(a) in (a ++ a) to be 2
     graph.getOrElse(_, Nil)
   }
 

--- a/summingbird-core/src/test/scala/com/twitter/summingbird/graph/ExpressionDagTests.scala
+++ b/summingbird-core/src/test/scala/com/twitter/summingbird/graph/ExpressionDagTests.scala
@@ -177,6 +177,7 @@ object ExpressionDagTests extends Properties("ExpressionDag") {
   } yield Inc(chain, by)
 
   def genChain: Gen[Formula[Int]] = Gen.frequency((1, genConst), (3, genChainInc))
+
   property("CombineInc compresses linear Inc chains") = forAll(genChain) { chain =>
     ExpressionDag.applyRule(chain, toLiteral, CombineInc) match {
       case Constant(n) => true


### PR DESCRIPTION
We are using the DagOptimizer at stripe before planning to reduce the size of some online graphs (went from 115 storm bolts or so to 69 in one example).

However, even in the case where we reach 69, there are rules that don't seem to be fully applied and I have not yet found out why.

Anyway, more test coverage never hurts.