### PR TITLE
avoid name computation unless there is a cache miss

### DIFF
--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/ScaldingPlatform.scala
@@ -294,8 +294,6 @@ object Scalding {
     built: Map[Producer[Scalding, _], PipeFactory[_]],
     forceFanOut: Boolean = false): (PipeFactory[T], Map[Producer[Scalding, _], PipeFactory[_]]) = {
 
-    val names = dependants.namesOf(producer).map(_.id)
-
     def recurse[U](p: Producer[Scalding, U],
       built: Map[Producer[Scalding, _], PipeFactory[_]] = built,
       forceFanOut: Boolean = forceFanOut): (PipeFactory[U], Map[Producer[Scalding, _], PipeFactory[_]]) = {
@@ -331,6 +329,9 @@ object Scalding {
     built.get(producer) match {
       case Some(pf) => (pf.asInstanceOf[PipeFactory[T]], built)
       case None =>
+        // make sure not to compute names unless we need them because it
+        // is somewhat expensive especially for large graphs
+        lazy val names = dependants.namesOf(producer).map(_.id)
         val (pf, m) = producer match {
           case Source(src) => {
             val shards = getOrElse(options, names, producer, FlatMapShards.default).count


### PR DESCRIPTION
This is eating a ton of time on our big graphs: we always recompute names even if we hit the cache. For graphs that fork and join a bunch, this can make planning in summingbird exponentially complex.

By moving it, we only compute names when needed and only on a cache miss.