### PR TITLE
Make mergeBatched protected instead of private.

### DIFF
--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/batch/BatchedStore.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/batch/BatchedStore.scala
@@ -154,7 +154,7 @@ trait BatchedStore[K, V] extends scalding.Store[K, V] { self =>
    * we are guaranteed to have sufficient input and deltas to cover these batches
    * and that the batches are given in order
    */
-  private def mergeBatched(inBatch: BatchID,
+  protected def mergeBatched(inBatch: BatchID,
     input: FlowProducer[TypedPipe[(K, V)]],
     deltas: FlowToPipe[(K, V)],
     readTimespan: Interval[Timestamp],


### PR DESCRIPTION
There are reasons why particular implementations might want to
override this method (for example, to support custom serialization
strategies), so let's make it protected instead of private.