### PR TITLE
Producer: adds `withFilter` to support scala 2.12 for-comprehensions

### DIFF
--- a/summingbird-core/src/main/scala/com/twitter/summingbird/Producer.scala
+++ b/summingbird-core/src/main/scala/com/twitter/summingbird/Producer.scala
@@ -243,6 +243,8 @@ sealed trait Producer[P <: Platform[P], +T] { self: Product =>
     // Enforce using the OptionMapped here:
     optionMap(Some(_).filter(fn))
 
+  def withFilter(fn: T => Boolean): Producer[P, T] = filter(fn)
+
   /**
    * This is identical to a certain leftJoin:
    * map((_, ())).leftJoin(srv).mapValues{case (_, v) => v}


### PR DESCRIPTION
scala 2.12.0 now requires `withFilter` for for-comprehension desugaring

https://www.scala-lang.org/news/2.12.0/
https://github.com/scala/scala/pull/5252