### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,18 @@
+container:
+  image: bigtruedata/sbt:latest
+  cpu: 4
+  memory: 12G
+
+test_task:
+  env:
+    LOG4J: file://$CIRRUS_WORKING_DIR/project/travis-log4j.properties
+    matrix:
+      TRAVIS_SCALA_VERSION: 2.12.4
+      TRAVIS_SCALA_VERSION: 2.11.12
+  ivy_cache:
+    folder: $HOME/.ivy2/cache
+    fingerprint_script: echo $TRAVIS_SCALA_VERSION
+  sbt_cache:
+    folder: $HOME/.sbt
+    fingerprint_script: echo $TRAVIS_SCALA_VERSION
+  test_script: ./sbt -Dlog4j.configuration=$LOG4J -DsequentialExecution=true ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -73,9 +73,9 @@ val sharedSettings = extraSettings ++ executionSettings ++ Seq(
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,
     Opts.resolver.sonatypeReleases,
-    "Clojars Repository" at "http://clojars.org/repo",
-    "Conjars Repository" at "http://conjars.org/repo",
-    "Twitter Maven" at "http://maven.twttr.com"
+    "Clojars Repository" at "https://clojars.org/repo",
+    "Conjars Repository" at "https://conjars.org/repo",
+    "Twitter Maven" at "https://maven.twttr.com"
   ),
 
   scalacOptions ++= Seq(


### PR DESCRIPTION
Cirrus CI allows to use more than 2 CPUs which speeds up tests drastically:

![image](https://user-images.githubusercontent.com/989066/43359139-8ea1f3c6-9252-11e8-9339-e9a39e1e530c.png)

Cirrus CI also provides more flexibility by using containers and very fast caching storage.

In case you'll decide to merge, an admin of Twitter organization must install Cirrus CI App from GitHub Marketplace: https://github.com/marketplace/cirrus-ci