### PR TITLE
Add `modifyBeforeWrite` extention point in `VersionedBatchStore`

### DIFF
--- a/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/store/VersionedBatchStore.scala
+++ b/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/store/VersionedBatchStore.scala
@@ -135,7 +135,7 @@ class VersionedBatchStore[K, V, K2, V2](rootPath: String, versionsToKeep: Int, o
 
     if (!target.sinkExists(mode)) {
       logger.info(s"Versioned batched store version for $this @ $newVersion doesn't exist. Will write out.")
-      lastVals.map(pack(batchID, _))
+      modifyBeforeWrite(lastVals).map(pack(batchID, _))
         .write(target)
     } else {
       logger.warn(s"Versioned batched store version for $this @ $newVersion already exists! Will skip adding to plan.")
@@ -151,4 +151,6 @@ class VersionedBatchStore[K, V, K2, V2](rootPath: String, versionsToKeep: Int, o
     TypedPipe.from(mappable)
       .map(unpack)
   }
+
+  protected def modifyBeforeWrite(lastVals: TypedPipe[(K, V)]): TypedPipe[(K, V)] = lastVals
 }


### PR DESCRIPTION
In order to better support different GDPR use cases in Twitter we need to have a way to do modification for stored `(K, V)` pairs in Summingbird's Scalding platform.

In this PR I've added `modifyBeforeWrite` protected method which suits this needs in `VersionedBatchStore`.