### PR TITLE
Avoid deprecated com.twitter.conversions

### DIFF
--- a/summingbird-example/src/main/scala/com/twitter/summingbird/example/Storage.scala
+++ b/summingbird-example/src/main/scala/com/twitter/summingbird/example/Storage.scala
@@ -19,7 +19,7 @@ package com.twitter.summingbird.example
 import com.twitter.algebird.Monoid
 import com.twitter.bijection.{ Base64String, Bijection, Codec, Injection }
 import com.twitter.bijection.netty.Implicits._
-import com.twitter.conversions.time._
+import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.memcached.KetamaClientBuilder
 import com.twitter.finagle.memcached.protocol.text.Memcached

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/FutureQueueLaws.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/FutureQueueLaws.scala
@@ -17,7 +17,7 @@
 package com.twitter.summingbird.online
 
 import com.twitter.bijection.twitter_util.UtilBijections
-import com.twitter.conversions.time._
+import com.twitter.conversions.DurationOps._
 import com.twitter.summingbird.online.option.{ MaxFutureWaitTime, MaxWaitingFutures }
 import com.twitter.util._
 import org.scalacheck._

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.summingbird.online.executor
 
-import com.twitter.conversions.time._
+import com.twitter.conversions.DurationOps._
 import com.twitter.summingbird.online.FutureQueue
 import com.twitter.summingbird.online.option.{ MaxEmitPerExecute, MaxFutureWaitTime, MaxWaitingFutures }
 import com.twitter.util.{ Await, Future, Promise }


### PR DESCRIPTION
Problem

Twitter's util deprecated `com.twitter.conversions.time` in https://github.com/twitter/util/commit/c4c33a3424c53cdad13b05536abfaa07eb78ff22.

Solution

Use `com.twitter.conversions.DurationOps`.