### PR TITLE
Completely avoid util conversions

### DIFF
--- a/summingbird-example/src/main/scala/com/twitter/summingbird/example/Storage.scala
+++ b/summingbird-example/src/main/scala/com/twitter/summingbird/example/Storage.scala
@@ -19,7 +19,6 @@ package com.twitter.summingbird.example
 import com.twitter.algebird.Monoid
 import com.twitter.bijection.{ Base64String, Bijection, Codec, Injection }
 import com.twitter.bijection.netty.Implicits._
-import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.memcached.KetamaClientBuilder
 import com.twitter.finagle.memcached.protocol.text.Memcached
@@ -27,6 +26,7 @@ import com.twitter.finagle.transport.Transport
 import com.twitter.storehaus.Store
 import com.twitter.storehaus.algebra.MergeableStore
 import com.twitter.storehaus.memcache.{ HashEncoder, MemcacheStore }
+import com.twitter.util.Duration
 import org.jboss.netty.buffer.ChannelBuffer
 
 /**
@@ -35,7 +35,7 @@ import org.jboss.netty.buffer.ChannelBuffer
  * pull req will make it easier to create Memcache store instances.
  */
 object Memcache {
-  val DEFAULT_TIMEOUT = 1.seconds
+  val DEFAULT_TIMEOUT = Duration.fromSeconds(1)
 
   def client = {
     val builder = ClientBuilder()

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/FutureQueueLaws.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/FutureQueueLaws.scala
@@ -17,7 +17,6 @@
 package com.twitter.summingbird.online
 
 import com.twitter.bijection.twitter_util.UtilBijections
-import com.twitter.conversions.DurationOps._
 import com.twitter.summingbird.online.option.{ MaxFutureWaitTime, MaxWaitingFutures }
 import com.twitter.util._
 import org.scalacheck._
@@ -74,7 +73,7 @@ class FutureQueueLaws extends Properties("FutureQueue") with Eventually {
     forAll { (futuresCount: NonNegativeShort, slackSpace: NonNegativeShort) =>
       val fq = new FutureQueue[Unit, Unit](
         MaxWaitingFutures(futuresCount.get + slackSpace.get),
-        MaxFutureWaitTime(20.seconds)
+        MaxFutureWaitTime(Duration.fromSeconds(20))
       )
       fq.addAll((0 until futuresCount.get).map { _ =>
         () -> Promise[Unit]
@@ -83,7 +82,7 @@ class FutureQueueLaws extends Properties("FutureQueue") with Eventually {
       val res = fq.dequeue(futuresCount.get)
       val end = Time.now
       res.isEmpty &&
-        (end - start < 15.seconds)
+        (end - start < Duration.fromSeconds(15))
       fq.numPendingOutstandingFutures.get == futuresCount.get
     }
 
@@ -92,7 +91,7 @@ class FutureQueueLaws extends Properties("FutureQueue") with Eventually {
       val count = inputs.size
       val fq = new FutureQueue[String, String](
         MaxWaitingFutures(count + 1),
-        MaxFutureWaitTime(20.seconds)
+        MaxFutureWaitTime(Duration.fromSeconds(20))
       )
       fq.addAll(inputs.map {
         case (state, t) =>
@@ -109,7 +108,7 @@ class FutureQueueLaws extends Properties("FutureQueue") with Eventually {
       val count = inputs.size
       val fq = new FutureQueue[String, String](
         MaxWaitingFutures(count + 1),
-        MaxFutureWaitTime(20.seconds)
+        MaxFutureWaitTime(Duration.fromSeconds(20))
       )
       inputs.foreach {
         case (state, t) =>
@@ -131,7 +130,7 @@ class FutureQueueLaws extends Properties("FutureQueue") with Eventually {
 
       val fq = new FutureQueue[Unit, Unit](
         MaxWaitingFutures(1),
-        MaxFutureWaitTime(20.seconds)
+        MaxFutureWaitTime(Duration.fromSeconds(20))
       )
       fq.addAll(mixedFutures.map { () -> _ })
 

--- a/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
+++ b/summingbird-online/src/test/scala/com/twitter/summingbird/online/executor/AsyncBaseSpec.scala
@@ -16,10 +16,9 @@
 
 package com.twitter.summingbird.online.executor
 
-import com.twitter.conversions.DurationOps._
 import com.twitter.summingbird.online.FutureQueue
 import com.twitter.summingbird.online.option.{ MaxEmitPerExecute, MaxFutureWaitTime, MaxWaitingFutures }
-import com.twitter.util.{ Await, Future, Promise }
+import com.twitter.util.{ Await, Duration, Future, Promise }
 import chain.Chain
 import org.scalatest.WordSpec
 import scala.util.Try
@@ -33,7 +32,7 @@ class AsyncBaseSpec extends WordSpec {
 
   class TestFutureQueue extends FutureQueue[Chain[Int], TraversableOnce[Int]](
     MaxWaitingFutures(100),
-    MaxFutureWaitTime(1.minute)
+    MaxFutureWaitTime(Duration.fromSeconds(60))
   ) {
     var added = false
     var addedData: (Chain[Int], Future[TraversableOnce[Int]]) = _
@@ -67,7 +66,7 @@ class AsyncBaseSpec extends WordSpec {
     tickData: => Future[TraversableOnce[(Chain[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented"),
     applyData: => Future[TraversableOnce[(Chain[Int], Future[TraversableOnce[Int]])]] = throw new RuntimeException("not implemented")) extends AsyncBase[Int, Int, Int](
     MaxWaitingFutures(100),
-    MaxFutureWaitTime(1.minute),
+    MaxFutureWaitTime(Duration.fromSeconds(60)),
     MaxEmitPerExecute(57)
   ) {
     override lazy val futureQueue = queue


### PR DESCRIPTION
Problem

As noted in https://github.com/twitter/summingbird/pull/774 Twitter util deprecated some conversions. However, summingbird is on an older version of util that does not have the new APIs.

Solution

Avoid the conversions sugar completely.